### PR TITLE
Update to cats-effect 3.x.x

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,8 +8,8 @@ object Dependencies {
   val `config-tools`       = "com.evolutiongaming"    %% "config-tools"          % "1.0.4"
   val nel                  = "com.evolutiongaming"    %% "nel"                   % "1.3.4"
   val `cassandra-launcher` = "com.evolutiongaming"    %% "cassandra-launcher"    % "0.0.4"
-  val `cats-helper`        = "com.evolutiongaming"    %% "cats-helper"           % "2.7.2"
-  val sstream              = "com.evolutiongaming"    %% "sstream"               % "0.2.1"
+  val `cats-helper`        = "com.evolutiongaming"    %% "cats-helper"           % "3.0.0"
+  val sstream              = "com.evolutiongaming"    %% "sstream"               % "1.0.0"
 
   object Logback {
     private val version = "1.2.7"
@@ -25,7 +25,7 @@ object Dependencies {
 
   object Cats {
     val core   = "org.typelevel" %% "cats-core"   % "2.7.0"
-    val effect = "org.typelevel" %% "cats-effect" % "2.5.4"
+    val effect = "org.typelevel" %% "cats-effect" % "3.2.9"
   }
 
   object Pureconfig {

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraCluster.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraCluster.scala
@@ -1,6 +1,6 @@
 package com.evolutiongaming.scassandra
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{MonadCancel, Resource, Sync}
 import cats.implicits._
 import cats.~>
 import com.datastax.driver.core.{Cluster => ClusterJ}
@@ -83,7 +83,7 @@ object CassandraCluster {
 
   implicit class CassandraClusterOps[F[_]](val self: CassandraCluster[F]) extends AnyVal {
 
-    def mapK[G[_]](f: F ~> G)(implicit G: Sync[G]): CassandraCluster[G] = new CassandraCluster[G] {
+    def mapK[G[_]](f: F ~> G)(implicit F: MonadCancel[F, _], G: MonadCancel[G, _]): CassandraCluster[G] = new CassandraCluster[G] {
 
       def connect = {
         for {

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraClusterOf.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraClusterOf.scala
@@ -1,7 +1,6 @@
 package com.evolutiongaming.scassandra
 
-import cats.effect.concurrent.Ref
-import cats.effect.{Resource, Sync}
+import cats.effect.{Ref, Resource, Sync}
 import cats.implicits._
 import com.evolutiongaming.scassandra.util.FromGFuture
 

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/syntax.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/syntax.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.scassandra
 
 import cats.effect.implicits._
-import cats.effect.{Concurrent, Sync}
+import cats.effect.{Async, Sync}
 import cats.syntax.all._
 import com.datastax.driver.core._
 import com.evolutiongaming.scassandra.util.FromGFuture
@@ -14,7 +14,7 @@ object syntax {
 
   implicit class ResultSetOps(val self: ResultSet) extends AnyVal {
 
-    def stream[F[_] : Concurrent : FromGFuture]: Stream[F, Row] = {
+    def stream[F[_]: Async: FromGFuture]: Stream[F, Row] = {
       val iterator = self.iterator()
       val fetch = FromGFuture[F].apply { self.fetchMoreResults() }.void
       val fetched = Sync[F].delay { self.isFullyFetched }

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/util/FromGFuture.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/util/FromGFuture.scala
@@ -23,7 +23,7 @@ object FromGFuture {
       def apply[A](future: => ListenableFuture[A]) = {
         for {
           future <- Sync[F].delay { future }
-          result <- Async[F].async[A] { callback =>
+          result <- Async[F].async_[A] { callback =>
             val futureCallback = new FutureCallback[A] {
               def onSuccess(a: A) = callback(a.asRight)
               def onFailure(e: Throwable) = callback(e.asLeft)

--- a/tests/src/test/scala/com/evolutiongaming/scassandra/IOSuite.scala
+++ b/tests/src/test/scala/com/evolutiongaming/scassandra/IOSuite.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.scassandra
 
-import cats.Parallel
-import cats.effect.{Concurrent, ContextShift, IO, Timer}
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
 import com.evolutiongaming.scassandra.util.FromGFuture
 import org.scalatest.Succeeded
 
@@ -12,11 +12,6 @@ object IOSuite {
   val Timeout: FiniteDuration = 10.seconds
 
   implicit val executor: ExecutionContextExecutor = ExecutionContext.global
-
-  implicit val contextShiftIO: ContextShift[IO] = IO.contextShift(executor)
-  implicit val concurrentIO: Concurrent[IO] = IO.ioConcurrentEffect
-  implicit val timerIO: Timer[IO] = IO.timer(executor)
-  implicit val parallelIO: Parallel[IO] = IO.ioParallel
   implicit val fromGFutureIO: FromGFuture[IO] = FromGFuture.lift[IO]
 
   def runIO[A](io: IO[A], timeout: FiniteDuration = Timeout): Future[Succeeded.type] = {


### PR DESCRIPTION
Unfortunately, I couldn't run all the tests as they rely on running a Cassandra instance and there were either M1 Silicon or Java 17-related issues.

This is what I got on Java 11 (M1 Mac):
```
11:20:39.025 ERROR o.a.c.u.NativeLibraryDarwin Failed to link the C library against JNA. Native methods will be unavailable.
java.lang.UnsatisfiedLinkError: /private/var/folders/zj/cc7rhdpd1tn6pp9f11ctkzsc0000gq/T/jna-1160005631/jna14795716455688662860.tmp: dlopen(/private/var/folders/zj/cc7rhdpd1tn6pp9f11ctkzsc0000gq/T/jna-1160005631/jna14795716455688662860.tmp, 0x0001): tried: '/private/var/folders/zj/cc7rhdpd1tn6pp9f11ctkzsc0000gq/T/jna-1160005631/jna14795716455688662860.tmp' (fat file, butjava.lang.RuntimeException: The native library could not be initialized properly. 
        at org.apache.cassandra.service.CassandraDaemon.exitOrFail(CassandraDaemon.java:770)
        at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:211)
        at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:631)
        at com.evolutiongaming.cassandra.StartCassandra$.apply(StartCassandra.scala:45)
 missing compatible architecture (have 'i386,x86_64', need 'arm64e')), '/usr/lib/jna14795716455688662860.tmp' (no such file)
        at java.base/java.lang.ClassLoader$NativeLibrary.load0(Native Method)
        at java.base/java.lang.ClassLoader$NativeLibrary.load(ClassLoader.java:2442)
        at java.base/java.lang.ClassLoader$NativeLibrary.loadLibrary(ClassLoader.java:2498)
        at java.base/java.lang.ClassLoader.loadLibrary0(ClassLoader.java:2694)
        at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2627)
        at java.base/java.lang.Runtime.load0(Runtime.java:768)
        at java.base/java.lang.System.load(System.java:1837)
        at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:851)
        at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:826)
        at com.sun.jna.Native.<clinit>(Native.java:140)
        at com.sun.jna.NativeLibrary.<clinit>(NativeLibrary.java:84)
        at org.apache.cassandra.utils.NativeLibraryDarwin.<clinit>(NativeLibraryDarwin.java:55)
        at org.apache.cassandra.utils.NativeLibrary.<clinit>(NativeLibrary.java:90)
        at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:203)
        at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:631)
        at com.evolutiongaming.cassandra.StartCassandra$.apply(StartCassandra.scala:45)
        at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra$lzycompute(CassandraSpec.scala:25)
        at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra(CassandraSpec.scala:25)
        at com.evolutiongaming.scassandra.CassandraSpec.beforeAll(C     at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra$lzycompute(CassandraSpec.scala:25)
        at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra(CassandraSpec.scala:25)
        at com.evolutiongaming.scassandra.CassandraSpec.afterAll(CassandraSpec.scala:50)
        at org.scalatest.BeforeAndAfterAll.$anonfun$run$1(BeforeAndAfterAll.scala:225)
        at org.scalatest.Status.$anonfun$withAfterEffect$1(Status.scala:377)
        at org.scalatest.Status.$anonfun$withAfterEffect$1$adapted(Status.scala:373)
        at org.scalatest.FailedStatus$.whenCompleted(Status.scala:505)
        at org.scalatest.Status.withAfterEffect(Status.scala:373)
        at org.scalatest.Status.withAfterEffect$(Status.scala:371)
        at org.scalatest.FailedStatus$.withAfterEffect(Status.scala:477)
        at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:224)
        at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
        at com.evolutiongaming.scassandra.CassandraSpec.run(CassandraSpec.scala:21)
        at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:318)
        at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:513)
        at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:413)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
assandraSpec.scala:45)
        at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
        at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
        at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
        at com.evolutiongaming.scassandra.CassandraSpec.run(CassandraSpec.scala:21)
        at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:318)
        at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:513)
        at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:413)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```

And this is what I got on Java 17 (still M1 Mac):
```
[info]   java.lang.RuntimeException: Exception encountered during startup
[info]   at org.apache.cassandra.service.CassandraDaemon.exitOrFail(CassandraDaemon.java:770)
[info]   at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:661)
[info]   at com.evolutiongaming.cassandra.StartCassandra$.apply(StartCassandra.scala:45)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra$lzycompute(CassandraSpec.scala:25)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra(CassandraSpec.scala:25)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.beforeAll(CassandraSpec.scala:45)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.run(CassandraSpec.scala:21)
[info]   ...
[info]   Cause: java.lang.AssertionError: java.lang.reflect.InaccessibleObjectException: Unable to make field private int java.io.FileDescriptor.fd accessible: module java.base does not "opens java.io" to unnamed module @38899305
[info]   at org.apache.cassandra.utils.FBUtilities.getProtectedField(FBUtilities.java:664)
[info]   at org.apache.cassandra.utils.NativeLibrary.<clinit>(NativeLibrary.java:82)
[info]   at org.apache.cassandra.service.CassandraDaemon.setup(CassandraDaemon.java:203)
[info]   at org.apache.cassandra.service.CassandraDaemon.activate(CassandraDaemon.java:631)
[info]   at com.evolutiongaming.cassandra.StartCassandra$.apply(StartCassandra.scala:45)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra$lzycompute(CassandraSpec.scala:25)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.shutdownCassandra(CassandraSpec.scala:25)
[info]   at com.evolutiongaming.scassandra.CassandraSpec.beforeAll(CassandraSpec.scala:45)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:212)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   ...

```