### PR TITLE
Add StreamingCassandraSession

### DIFF
--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
@@ -8,8 +8,6 @@ import com.evolutiongaming.scassandra.util.FromGFuture
 import com.evolutiongaming.sstream.FoldWhile.FoldWhileOps
 import com.evolutiongaming.sstream.Stream
 
-import java.util
-
 object StreamingCassandraSession {
   implicit final class StreamingCassandraSessionOps[F[_]](val self: CassandraSession[F]) extends AnyVal {
     def executeStream(statement: Statement)(implicit F: Async[F]): Stream[F, Row] = {
@@ -23,7 +21,7 @@ object StreamingCassandraSession {
   }
 
   private def toStream[F[_]: Async](resultSet: ResultSet): Stream[F, Row] = {
-    val iterator: util.Iterator[Row] = resultSet.iterator()
+    val iterator: java.util.Iterator[Row] = resultSet.iterator()
     val fetch: F[Unit] = FromGFuture[F].apply(resultSet.fetchMoreResults()).void
     val fetched: F[Boolean] = Async[F].delay(resultSet.isFullyFetched)
     val next: F[List[Row]] = Async[F].delay(List.fill(resultSet.getAvailableWithoutFetching)(iterator.next()))

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
@@ -1,0 +1,87 @@
+package com.evolutiongaming.scassandra
+
+import cats.effect.Async
+import cats.effect.syntax.spawn._
+import cats.syntax.all._
+import com.evolutiongaming.scassandra.util.FromGFuture
+import com.evolutiongaming.sstream.Stream
+import com.evolutiongaming.sstream.FoldWhile.FoldWhileOps
+import com.datastax.driver.core.{RegularStatement, ResultSet, Row, SimpleStatement, Statement}
+
+/** 
+ *  A `CassandraSession` that supports streaming results from Cassandra using `sstream.Stream` 
+ */
+trait StreamingCassandraSession[F[_]] extends CassandraSession[F] {
+  def executeStream(statement: Statement): Stream[F, Row]
+
+  final def executeStream(statement: String): Stream[F, Row] = executeStream(new SimpleStatement(statement))
+}
+
+object StreamingCassandraSession {
+  def of[F[_]: Async](session: CassandraSession[F]): StreamingCassandraSession[F] = {
+    new StreamingCassandraSession[F] {
+      def loggedKeyspace = session.loggedKeyspace
+
+      def init = session.init
+
+      def execute(query: String) = session.execute(query)
+
+      def execute(query: String, values: Any*) = session.execute(query, values: _*)
+
+      def execute(query: String, values: Map[String, AnyRef]) = session.execute(query, values)
+
+      def execute(statement: Statement) = session.execute(statement)
+
+      def prepare(query: String) = session.prepare(query)
+
+      def prepare(statement: RegularStatement) = session.prepare(statement)
+
+      def state = session.state
+
+      def executeStream(statement: Statement) = {
+        for {
+          resultSet <- Stream.lift(execute(statement))
+          row       <- toStream(resultSet)
+        } yield row
+      }
+
+      private def toStream(resultSet: ResultSet): Stream[F, Row] = {
+        val iterator = resultSet.iterator()
+        val fetch = FromGFuture[F].apply(resultSet.fetchMoreResults()).void 
+        val fetched = Async[F].delay(resultSet.isFullyFetched)
+        val next = Async[F].delay(List.fill(resultSet.getAvailableWithoutFetching)(iterator.next()))
+
+        new Stream[F, Row] {
+          def foldWhileM[L, R](l: L)(f: (L, Row) => F[Either[L, R]]) = {
+            l.tailRecM[F, Either[L, R]] { l =>
+              def apply(rows: List[Row]) = {
+                for {
+                  result <- rows.foldWhileM(l)(f)
+                } yield {
+                  result.asRight[L]
+                }
+              }
+
+              def fetchAndApply(rows: List[Row]) = {
+                for {
+                  fetching <- fetch.start
+                  result   <- rows.foldWhileM(l)(f)
+                  result   <- result match {
+                    case l: Left[L, R]  => fetching.joinWithNever as l.rightCast[Either[L, R]]
+                    case r: Right[L, R] => r.leftCast[L].asRight[L].pure[F]
+                  }
+                } yield result
+              }
+
+              for {
+                fetched <- fetched
+                rows    <- next
+                result  <- if (fetched) apply(rows) else fetchAndApply(rows)
+              } yield result
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/StreamingCassandraSession.scala
@@ -1,120 +1,58 @@
 package com.evolutiongaming.scassandra
 
 import cats.effect.Async
-import cats.effect.syntax.spawn._
-import cats.syntax.all._
-import cats.~>
+import cats.effect.syntax.spawn.*
+import cats.syntax.all.*
+import com.datastax.driver.core.{ResultSet, Row, SimpleStatement, Statement}
 import com.evolutiongaming.scassandra.util.FromGFuture
-import com.evolutiongaming.sstream.Stream
 import com.evolutiongaming.sstream.FoldWhile.FoldWhileOps
-import com.datastax.driver.core.{RegularStatement, ResultSet, Row, SimpleStatement, Statement}
+import com.evolutiongaming.sstream.Stream
 
-/** 
- *  A `CassandraSession` that supports streaming results from Cassandra using `sstream.Stream`.
- */
-trait StreamingCassandraSession[F[_]] extends CassandraSession[F] {
-  def executeStream(statement: Statement): Stream[F, Row]
-
-  final def executeStream(statement: String): Stream[F, Row] = executeStream(new SimpleStatement(statement))
-}
+import java.util
 
 object StreamingCassandraSession {
-  /** 
-   *  Wrap a `CassandraSession` in a `StreamingCassandraSession`.
-   *  Creates a thin wrapper around the `CassandraSession` that induces no overhead
-   *  except for the memory footprint of the wrapper itself and doesn't allocate any additional 
-   *  resources.
-   */
-  def of[F[_]: Async](session: CassandraSession[F]): StreamingCassandraSession[F] = {
-    new StreamingCassandraSession[F] {
-      def loggedKeyspace = session.loggedKeyspace
-
-      def init = session.init
-
-      def execute(query: String) = session.execute(query)
-
-      def execute(query: String, values: Any*) = session.execute(query, values: _*)
-
-      def execute(query: String, values: Map[String, AnyRef]) = session.execute(query, values)
-
-      def execute(statement: Statement) = session.execute(statement)
-
-      def prepare(query: String) = session.prepare(query)
-
-      def prepare(statement: RegularStatement) = session.prepare(statement)
-
-      def state = session.state
-
-      def executeStream(statement: Statement) = {
-        for {
-          resultSet <- Stream.lift(execute(statement))
-          row       <- toStream(resultSet)
-        } yield row
-      }
-
-      private def toStream(resultSet: ResultSet): Stream[F, Row] = {
-        val iterator = resultSet.iterator()
-        val fetch = FromGFuture[F].apply(resultSet.fetchMoreResults()).void 
-        val fetched = Async[F].delay(resultSet.isFullyFetched)
-        val next = Async[F].delay(List.fill(resultSet.getAvailableWithoutFetching)(iterator.next()))
-
-        new Stream[F, Row] {
-          def foldWhileM[L, R](l: L)(f: (L, Row) => F[Either[L, R]]) = {
-            l.tailRecM[F, Either[L, R]] { l =>
-              def apply(rows: List[Row]) = {
-                for {
-                  result <- rows.foldWhileM(l)(f)
-                } yield {
-                  result.asRight[L]
-                }
-              }
-
-              def fetchAndApply(rows: List[Row]) = {
-                for {
-                  fetching <- fetch.start
-                  result   <- rows.foldWhileM(l)(f)
-                  result   <- result match {
-                    case l: Left[L, R]  => fetching.joinWithNever as l.rightCast[Either[L, R]]
-                    case r: Right[L, R] => r.leftCast[L].asRight[L].pure[F]
-                  }
-                } yield result
-              }
-
-              for {
-                fetched <- fetched
-                rows    <- next
-                result  <- if (fetched) apply(rows) else fetchAndApply(rows)
-              } yield result
-            }
-          }
-        }
-      }
+  implicit final class StreamingCassandraSessionOps[F[_]](val self: CassandraSession[F]) extends AnyVal {
+    def executeStream(statement: Statement)(implicit F: Async[F]): Stream[F, Row] = {
+      for {
+        resultSet <- Stream.lift(self.execute(statement))
+        row       <- toStream(resultSet)
+      } yield row
     }
+
+    def executeStream(statement: String)(implicit F: Async[F]): Stream[F, Row] = executeStream(new SimpleStatement(statement))
   }
 
-  implicit class StreamingSessionOps[F[_]](val self: StreamingCassandraSession[F]) extends AnyVal {
+  private def toStream[F[_]: Async](resultSet: ResultSet): Stream[F, Row] = {
+    val iterator: util.Iterator[Row] = resultSet.iterator()
+    val fetch: F[Unit] = FromGFuture[F].apply(resultSet.fetchMoreResults()).void
+    val fetched: F[Boolean] = Async[F].delay(resultSet.isFullyFetched)
+    val next: F[List[Row]] = Async[F].delay(List.fill(resultSet.getAvailableWithoutFetching)(iterator.next()))
 
-    def mapK[G[_]](f: F ~> G, g: G ~> F): StreamingCassandraSession[G] = new StreamingCassandraSession[G] {
+    new Stream[F, Row] {
+      def foldWhileM[L, R](l: L)(f: (L, Row) => F[Either[L, R]]): F[Either[L, R]] = {
+        l.tailRecM[F, Either[L, R]] { l =>
+          def apply(rows: List[Row]): F[Either[L, Either[L, R]]] = {
+            rows.foldWhileM(l)(f).map(_.asRight[L])
+          }
 
-      def loggedKeyspace = f(self.loggedKeyspace)
+          def fetchAndApply(rows: List[Row]): F[Either[L, Either[L, R]]] = {
+            for {
+              fetching <- fetch.start
+              result   <- rows.foldWhileM(l)(f)
+              result   <- result match {
+                case l: Left[L, R]  => fetching.joinWithNever.as(l.rightCast[Either[L, R]])
+                case r: Right[L, R] => r.leftCast[L].asRight[L].pure[F]
+              }
+            } yield result
+          }
 
-      def init = f(self.init)
-
-      def execute(query: String) = f(self.execute(query))
-
-      def execute(query: String, values: Any*) = f(self.execute(query, values: _*))
-
-      def execute(query: String, values: Map[String, AnyRef]) = f(self.execute(query, values))
-
-      def execute(statement: Statement) = f(self.execute(statement))
-
-      def executeStream(statement: Statement) = self.executeStream(statement).mapK(f, g)
-
-      def prepare(query: String) = f(self.prepare(query))
-
-      def prepare(statement: RegularStatement) = f(self.prepare(statement))
-
-      def state = self.state.mapK(f)
+          for {
+            fetched <- fetched
+            rows    <- next
+            result  <- if (fetched) apply(rows) else fetchAndApply(rows)
+          } yield result
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
### Motivation
While untangling `kafka-flow` from `kafka-journal` (https://github.com/evolution-gaming/kafka-flow/issues/592), I noticed that there exists [`com.evolutiongaming.kafka.journal.eventual.cassandra.CassandraSession`](https://github.com/evolution-gaming/kafka-journal/blob/2cee20621a8d7e2b410946dfd60ef514a4637060/cassandra/src/main/scala/com/evolutiongaming/kafka/journal/eventual/cassandra/CassandraSession.scala) that adds support for using `sstream.Stream` to execute queries while delegating the actual interaction to the underlying `CassandraSession` from `scassandra`. Since `scassandra` already depends on `sstream` there seems to be no reason not to have streaming support in the base library

### Implementation
Just new extension methods. The implementation delegates all work to the passed `CassandraSession`.

Q: why not `execute`?
A: there's an already existing `execute` method with a different return type

Q: why not add the method to the existing trait?
A: new functionality requires `Async` instead of `Sync` (tagless fucking final, yay!), so the choice was between releasing a new major version and breaking source and binary compatibility for downstream libraries (not cool) and this (cooler and doesn't bother anyone)