### PR TITLE
Add Java driver Cluster hooks to CassandraClusterOf

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
   val `executor-tools`           = "com.evolutiongaming"    %% "executor-tools"                  % "1.0.5"
   val `config-tools`             = "com.evolutiongaming"    %% "config-tools"                    % "1.0.5"
   val nel                        = "com.evolutiongaming"    %% "nel"                             % "1.3.5"
-  val `testcontainers-cassandra` = "com.dimafeng"           %% "testcontainers-scala-cassandra"  % "0.43.6"
+  val `testcontainers-cassandra` = "com.dimafeng"           %% "testcontainers-scala-cassandra"  % "0.44.1"
   val `cats-helper`              = "com.evolutiongaming"    %% "cats-helper"                     % "3.9.0"
   val sstream                    = "com.evolutiongaming"    %% "sstream"                         % "1.1.0"
 

--- a/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraClusterOf.scala
+++ b/scassandra/src/main/scala/com/evolutiongaming/scassandra/CassandraClusterOf.scala
@@ -1,41 +1,88 @@
 package com.evolutiongaming.scassandra
 
+import cats.Applicative
 import cats.effect.{Ref, Resource, Sync}
-import cats.implicits._
+import cats.implicits.*
+import com.datastax.driver.core.Cluster as ClusterJ
 import com.evolutiongaming.scassandra.util.FromGFuture
 
 trait CassandraClusterOf[F[_]] {
 
   def apply(config: CassandraConfig): Resource[F, CassandraCluster[F]]
+
+  /**
+   * Creates a new [[CassandraClusterOf]] instance with an added hook for observing the value of
+   * the underlying Java Cassandra driver `Cluster` object used for [[CassandraCluster]] creation.
+   *
+   * This method can be used to register listeners to the Java Cassandra driver `Cluster`.
+   */
+  def addClusterJObserveHook(f: ClusterJ => F[Unit]): CassandraClusterOf[F] = {
+    // TODO: [6.0.0 release] remove this default implementation
+    // no-op default implementation to preserve bincompat for 5.5.x
+
+    this
+  }
+
+  /**
+   * Create a new [[CassandraClusterOf]] instance with all the hooks added by
+   * [[addClusterJObserveHook]] method removed.
+   */
+  def removeAllClusterJObserveHooks(): CassandraClusterOf[F] = {
+    // TODO: [6.0.0 release] remove this default implementation
+    // no-op default implementation to preserve bincompat for 5.5.x
+
+    this
+  }
 }
 
 object CassandraClusterOf {
 
   def apply[F[_]](implicit F: CassandraClusterOf[F]): CassandraClusterOf[F] = F
-  
+
 
   def of[F[_] : Sync : FromGFuture]: F[CassandraClusterOf[F]] = {
     for {
-      clusterId  <- Ref[F].of(0)
-      clusterId1  = clusterId.modify { a =>
-        val a1 = a + 1
-        (a1, a1)
-      }
+      clusterIdRef <- Ref[F].of(0)
     } yield {
-      apply(clusterId1)
+      makeImpl(genClusterId = clusterIdRef.updateAndGet(_ + 1))
     }
   }
 
 
-  private def apply[F[_] : Sync : FromGFuture](clusterId: F[Int]): CassandraClusterOf[F] = {
-    new CassandraClusterOf[F] {
-      def apply(config: CassandraConfig) = {
-        val cluster = for {
-          clusterId <- clusterId
-          cluster   <- Sync[F].delay { CreateClusterJ(config, clusterId) }
-        } yield cluster
-        CassandraCluster.of(cluster)
-      }
+  private def makeImpl[F[_] : Sync : FromGFuture](genClusterId: F[Int]): CassandraClusterOf[F] = {
+    new CassandraClusterOfImpl(
+      genClusterId = genClusterId,
+      clusterJObserveHook = _ => Applicative[F].unit,
+    )
+  }
+
+  private final class CassandraClusterOfImpl[F[_] : Sync : FromGFuture]
+  (
+    genClusterId: F[Int],
+    clusterJObserveHook: ClusterJ => F[Unit],
+  ) extends CassandraClusterOf[F] {
+    override def apply(config: CassandraConfig): Resource[F, CassandraCluster[F]] = {
+      val clusterJ = for {
+        clusterId <- genClusterId
+        clusterJ <- Sync[F].delay {
+          CreateClusterJ(config, clusterId)
+        }
+      } yield clusterJ
+      CassandraCluster.of(clusterJ.flatTap(clusterJObserveHook))
+    }
+
+    override def addClusterJObserveHook(f: ClusterJ => F[Unit]): CassandraClusterOf[F] = {
+      new CassandraClusterOfImpl[F](
+        genClusterId = genClusterId,
+        clusterJObserveHook = clusterJ => clusterJObserveHook(clusterJ).flatTap(_ => f(clusterJ)),
+      )
+    }
+
+    override def removeAllClusterJObserveHooks(): CassandraClusterOf[F] = {
+      new CassandraClusterOfImpl[F](
+        genClusterId = genClusterId,
+        clusterJObserveHook = _ => Applicative[F].unit,
+      )
     }
   }
 }

--- a/tests/src/test/scala/com/evolutiongaming/scassandra/CassandraSpec.scala
+++ b/tests/src/test/scala/com/evolutiongaming/scassandra/CassandraSpec.scala
@@ -22,7 +22,7 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class CassandraSpec extends AnyWordSpec with BeforeAndAfterAll with Matchers {
   private lazy val cassandraContainer = CassandraContainer(
-    dockerImageNameOverride = DockerImageName.parse("cassandra:3.11.7"),
+    image = DockerImageName.parse("cassandra:3.11.7"),
   )
 
   private lazy val config = 


### PR DESCRIPTION
This will allow clients to register listeners to the Java driver Cluster created by CassandraClusterOf.

Binary compatibility preserved.

Also:
- updated testcontainers-scala-cassandra to the latest version so it works with rancher on ARM macs