### PR TITLE
Pin patched Netty, Jackson and Guava versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,9 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.13.18", "3.3.8"),
   Compile / doc / scalacOptions ++= Seq("-groups", "-implicits", "-no-link-warnings"),
   publishTo := Some(Resolver.evolutionReleases),
+  // Netty guarantees binary compatibility within 4.1.x, but its `.Final` qualifier
+  // makes the early-semver check reject patch bumps.
+  libraryDependencySchemes += "io.netty" % "netty-*" % VersionScheme.Always,
   licenses := Seq(("MIT", url("https://opensource.org/licenses/MIT"))),
   scalacOptions ++= Seq(
     "-release:11",
@@ -79,9 +82,18 @@ lazy val scassandra = (project in file("scassandra"))
       nel,
       `cassandra-driver`,
       jffi,
+      Netty.common,
+      Netty.codec,
+      Netty.handler,
+      Jackson.core,
+      Jackson.databind,
+      guava,
       `executor-tools`,
       Pureconfig.cats,
     ),
+    // Guava major bump is a security fix. The only Guava type in the public API is
+    // `ListenableFuture`, which is unchanged since 19.0.
+    versionPolicyIgnored += "com.google.guava" % "guava",
   )
   .settings(
     libraryDependencies ++= crossSettings(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,26 @@ object Dependencies {
   // TODO: remove explicit dependency when driver 3 support dropped
   val jffi = "com.github.jnr" % "jffi" % "1.3.14"
 
+  // The Cassandra driver 3 pulls in outdated Netty, Jackson and Guava versions with known CVEs.
+  // Pin them explicitly so both this build and downstream consumers resolve the patched ones.
+  //
+  // when updating, make sure they stay compatible with the driver version used
+  // TODO: remove explicit dependencies when driver 3 support dropped
+  object Netty {
+    private val version = "4.1.136.Final"
+    val common = "io.netty" % "netty-common" % version
+    val codec = "io.netty" % "netty-codec" % version
+    val handler = "io.netty" % "netty-handler" % version
+  }
+
+  object Jackson {
+    private val version = "2.18.8"
+    val core = "com.fasterxml.jackson.core" % "jackson-core" % version
+    val databind = "com.fasterxml.jackson.core" % "jackson-databind" % version
+  }
+
+  val guava = "com.google.guava" % "guava" % "33.5.0-jre"
+
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.20"
   val `executor-tools` = "com.evolutiongaming" %% "executor-tools" % "1.0.5"
   val `config-tools` = "com.evolutiongaming" %% "config-tools" % "1.0.5"


### PR DESCRIPTION
All 46 open Dependabot alerts come in transitively via cassandra-driver 3.11.5. Pinning netty 4.1.136, jackson 2.18.8 and guava 33.5.0-jre in libraryDependencies clears them, and downstream consumers get the patched versions too.

Netty needs a VersionScheme.Always entry because its `.Final` suffix confuses the early-semver check. Guava 19 to 33 is a real major bump, so it is ignored explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with supported Cassandra driver components and their latest patch-level updates.
  - Updated a third-party library to address a known security issue without changing existing future-related functionality.

- **Chores**
  - Refined build configuration to improve version validation and ensure consistent library versions across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->