### PR TITLE
Bump Jackson to 2.18.10

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   }
 
   object Jackson {
-    private val version = "2.18.8"
+    private val version = "2.18.9"
     val core = "com.fasterxml.jackson.core" % "jackson-core" % version
     val databind = "com.fasterxml.jackson.core" % "jackson-databind" % version
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -24,7 +24,7 @@ object Dependencies {
   }
 
   object Jackson {
-    private val version = "2.18.9"
+    private val version = "2.18.10"
     val core = "com.fasterxml.jackson.core" % "jackson-core" % version
     val databind = "com.fasterxml.jackson.core" % "jackson-databind" % version
   }


### PR DESCRIPTION
Three new jackson-databind advisories were published after #367 merged, all `@JsonView` / `@JsonIgnoreProperties` bypasses fixed in 2.18.10. Nothing else is flagged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated underlying libraries to incorporate the latest maintenance and compatibility improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->