### PR TITLE
Migrate build to sbt 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
   test:
     uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1
     with:
-      java_version: '11'
+      java_version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,4 +11,6 @@ permissions:
 jobs:
   release:
     uses: evolution-gaming/scala-github-actions/.github/workflows/release.yml@61f111a4472fde7b63e5921ac8a238f22d1bb028 # v7.0.1
+    with:
+      verify_sbt_command: 'cleanFull; +check; +all testFull package'
     secrets: inherit

--- a/build.sbt
+++ b/build.sbt
@@ -58,10 +58,10 @@ addCommandAlias("fmt", "+all scalafmtAll scalafmtSbt")
 // check needed for Evo workflows/release.yml - it adds '+' before calling check,
 // tests are executed separately
 addCommandAlias("check", "all scalafmtCheckAll scalafmtSbtCheck versionPolicyCheck Compile/doc")
-addCommandAlias("build", "; +check; +test")
+addCommandAlias("build", "; +check; +testFull")
 
 lazy val root = (project in file("."))
-  .settings(name := "scassandra")
+  .settings(name := "scassandra-root")
   .settings(commonSettings)
   .settings(
     publish / skip := true,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.13.0
+sbt.version=2.0.8


### PR DESCRIPTION
Plugins publish sbt 2 builds at the versions we already use, so plugins.sbt is untouched. Root renamed to scassandra-root: sbt 2 derives output dirs from name, which clashed with the module. CI needs JDK 17, sbt 2 won't run on 11, artifacts still target Java 11. Release verifies with cleanFull/testFull.