### PR TITLE
Add Mergify merge queue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,1 @@
+extends: scala-github-actions


### PR DESCRIPTION
Extends the shared config in scala-github-actions: approved PRs get rebased on master, CI reruns, then merge. scala-steward updates queue without approval, do-not-merge opts out. The check names it keys on already match our CI. Needs the Mergify app installed on the repo before it does anything.