### PR TITLE
Add unit tests before driver 4 migration

### DIFF
--- a/scassandra/src/test/scala/com/datastax/driver/core/DriverMocks.scala
+++ b/scassandra/src/test/scala/com/datastax/driver/core/DriverMocks.scala
@@ -1,0 +1,19 @@
+package com.datastax.driver.core
+
+object CloseFutureMock {
+
+  def apply(): CloseFuture = CloseFuture.immediateFuture()
+}
+
+object ColumnDefinitionsMock {
+
+  val empty: ColumnDefinitions = ColumnDefinitions.EMPTY
+}
+
+object PreparedIdMock {
+
+  val empty: PreparedId = {
+    val metadata = new PreparedId.PreparedMetadata(MD5Digest.wrap(Array.empty[Byte]), ColumnDefinitions.EMPTY)
+    new PreparedId(metadata, metadata, Array.empty[Int], ProtocolVersion.V4)
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
@@ -13,6 +13,7 @@ import com.datastax.driver.core.policies.{
 }
 import com.datastax.driver.core.{AuthProvider, Cluster as ClusterJ, PlainTextAuthProvider}
 import com.evolutiongaming.nel.Nel
+import com.evolutiongaming.scassandra.MockSupport.notSupported
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -155,11 +156,11 @@ class CassandraClusterSpec extends AnyWordSpec with Matchers {
 
     "mapK" in {
       val cluster = new CassandraCluster[IO] {
-        def connect: Resource[IO, CassandraSession[IO]] = sys.error("not supported")
-        def connect(keyspace: String): Resource[IO, CassandraSession[IO]] = sys.error("not supported")
+        def connect: Resource[IO, CassandraSession[IO]] = notSupported
+        def connect(keyspace: String): Resource[IO, CassandraSession[IO]] = notSupported
         def clusterName: IO[String] = IO.pure("name")
-        def newSession: Resource[IO, CassandraSession[IO]] = sys.error("not supported")
-        def metadata: IO[Metadata[IO]] = sys.error("not supported")
+        def newSession: Resource[IO, CassandraSession[IO]] = notSupported
+        def metadata: IO[Metadata[IO]] = notSupported
       }
       cluster.mapK(FunctionK.id[IO]).clusterName.unsafeRunSync() shouldEqual "name"
     }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
@@ -3,6 +3,7 @@ package com.evolutiongaming.scassandra
 import cats.arrow.FunctionK
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Ref, Resource}
+import com.datastax.driver.core.ProtocolOptions.Compression
 import com.datastax.driver.core.policies.{
   ConstantSpeculativeExecutionPolicy,
   DCAwareRoundRobinPolicy,
@@ -10,7 +11,6 @@ import com.datastax.driver.core.policies.{
   NoSpeculativeExecutionPolicy,
   TokenAwarePolicy,
 }
-import com.datastax.driver.core.ProtocolOptions.Compression
 import com.datastax.driver.core.{AuthProvider, Cluster as ClusterJ, PlainTextAuthProvider}
 import com.evolutiongaming.nel.Nel
 import org.scalatest.matchers.should.Matchers
@@ -55,7 +55,6 @@ class CassandraClusterSpec extends AnyWordSpec with Matchers {
       }
     }
 
-
     "apply load balancing policy when set" in {
       withClusterJ(CassandraConfig(loadBalancing = Some(LoadBalancingConfig(localDc = "dc1")))) { cluster =>
         val policy = cluster.getConfiguration.getPolicies.getLoadBalancingPolicy
@@ -66,7 +65,8 @@ class CassandraClusterSpec extends AnyWordSpec with Matchers {
 
     "apply speculative execution policy when set" in {
       withClusterJ(CassandraConfig(speculativeExecution = Some(SpeculativeExecutionConfig()))) {
-        _.getConfiguration.getPolicies.getSpeculativeExecutionPolicy shouldBe a[ConstantSpeculativeExecutionPolicy]
+        _.getConfiguration.getPolicies.getSpeculativeExecutionPolicy shouldBe
+          a[ConstantSpeculativeExecutionPolicy]
       }
       withClusterJ(CassandraConfig()) {
         _.getConfiguration.getPolicies.getSpeculativeExecutionPolicy shouldBe a[NoSpeculativeExecutionPolicy]
@@ -98,9 +98,11 @@ class CassandraClusterSpec extends AnyWordSpec with Matchers {
     }
 
     "reject malformed contact points" in {
-      val error = the[IllegalArgumentException] thrownBy CreateClusterJ(CassandraConfig(contactPoints = Nel("a:b:c")), 1)
+      val error = the[IllegalArgumentException] thrownBy
+        CreateClusterJ(CassandraConfig(contactPoints = Nel("a:b:c")), 1)
       error.getMessage should include("a:b:c")
-      a[NumberFormatException] should be thrownBy CreateClusterJ(CassandraConfig(contactPoints = Nel("127.0.0.1:port")), 1)
+      a[NumberFormatException] should be thrownBy
+        CreateClusterJ(CassandraConfig(contactPoints = Nel("127.0.0.1:port")), 1)
     }
   }
 
@@ -145,7 +147,10 @@ class CassandraClusterSpec extends AnyWordSpec with Matchers {
   "CassandraCluster" should {
 
     "expose the cluster name" in {
-      CassandraCluster.of[IO](CassandraConfig(name = "name"), clusterId = 3).use(_.clusterName).unsafeRunSync() shouldEqual "name-3"
+      CassandraCluster.of[IO](
+        CassandraConfig(name = "name"),
+        clusterId = 3,
+      ).use(_.clusterName).unsafeRunSync() shouldEqual "name-3"
     }
 
     "mapK" in {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraClusterSpec.scala
@@ -1,0 +1,162 @@
+package com.evolutiongaming.scassandra
+
+import cats.arrow.FunctionK
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
+import com.datastax.driver.core.policies.{
+  ConstantSpeculativeExecutionPolicy,
+  DCAwareRoundRobinPolicy,
+  ExponentialReconnectionPolicy,
+  NoSpeculativeExecutionPolicy,
+  TokenAwarePolicy,
+}
+import com.datastax.driver.core.ProtocolOptions.Compression
+import com.datastax.driver.core.{AuthProvider, Cluster as ClusterJ, PlainTextAuthProvider}
+import com.evolutiongaming.nel.Nel
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration.*
+
+class CassandraClusterSpec extends AnyWordSpec with Matchers {
+
+  private def withClusterJ[A](config: CassandraConfig, clusterId: Int = 1)(f: ClusterJ => A): A = {
+    val cluster = CreateClusterJ(config, clusterId)
+    try f(cluster)
+    finally cluster.close()
+  }
+
+  "CreateClusterJ" should {
+
+    "append the cluster id to the cluster name" in {
+      withClusterJ(CassandraConfig(name = "name"), clusterId = 7) { _.getClusterName shouldEqual "name-7" }
+    }
+
+    "apply socket, query, pooling and reconnection config" in {
+      val config = CassandraConfig(
+        port = 9043,
+        socket = SocketConfig(readTimeout = 1.second),
+        query = QueryConfig(fetchSize = 42),
+        pooling = PoolingConfig(maxQueueSize = 7),
+        reconnection = ReconnectionConfig(minDelay = 2.seconds, maxDelay = 3.seconds),
+        compression = Compression.NONE,
+      )
+      withClusterJ(config) { cluster =>
+        val configuration = cluster.getConfiguration
+        configuration.getSocketOptions.getReadTimeoutMillis shouldEqual 1000
+        configuration.getQueryOptions.getFetchSize shouldEqual 42
+        configuration.getPoolingOptions.getMaxQueueSize shouldEqual 7
+        configuration.getProtocolOptions.getPort shouldEqual 9043
+        configuration.getProtocolOptions.getCompression shouldEqual Compression.NONE
+        val reconnection = configuration.getPolicies.getReconnectionPolicy
+        reconnection shouldBe a[ExponentialReconnectionPolicy]
+        reconnection.asInstanceOf[ExponentialReconnectionPolicy].getBaseDelayMs shouldEqual 2000
+        reconnection.asInstanceOf[ExponentialReconnectionPolicy].getMaxDelayMs shouldEqual 3000
+      }
+    }
+
+
+    "apply load balancing policy when set" in {
+      withClusterJ(CassandraConfig(loadBalancing = Some(LoadBalancingConfig(localDc = "dc1")))) { cluster =>
+        val policy = cluster.getConfiguration.getPolicies.getLoadBalancingPolicy
+        policy shouldBe a[TokenAwarePolicy]
+        policy.asInstanceOf[TokenAwarePolicy].getChildPolicy shouldBe a[DCAwareRoundRobinPolicy]
+      }
+    }
+
+    "apply speculative execution policy when set" in {
+      withClusterJ(CassandraConfig(speculativeExecution = Some(SpeculativeExecutionConfig()))) {
+        _.getConfiguration.getPolicies.getSpeculativeExecutionPolicy shouldBe a[ConstantSpeculativeExecutionPolicy]
+      }
+      withClusterJ(CassandraConfig()) {
+        _.getConfiguration.getPolicies.getSpeculativeExecutionPolicy shouldBe a[NoSpeculativeExecutionPolicy]
+      }
+    }
+
+    "apply credentials when set" in {
+      withClusterJ(CassandraConfig(authentication = Some(AuthenticationConfig("user", Masked("pass"))))) {
+        _.getConfiguration.getProtocolOptions.getAuthProvider shouldBe a[PlainTextAuthProvider]
+      }
+      withClusterJ(CassandraConfig()) {
+        _.getConfiguration.getProtocolOptions.getAuthProvider shouldBe theSameInstanceAs(AuthProvider.NONE)
+      }
+    }
+
+    "disable metrics and JMX reporting by default" in {
+      withClusterJ(CassandraConfig()) { cluster =>
+        cluster.getConfiguration.getMetricsOptions.isEnabled shouldEqual false
+        cluster.getConfiguration.getMetricsOptions.isJMXReportingEnabled shouldEqual false
+      }
+      withClusterJ(CassandraConfig(metrics = true, jmxReporting = true)) { cluster =>
+        cluster.getConfiguration.getMetricsOptions.isEnabled shouldEqual true
+        cluster.getConfiguration.getMetricsOptions.isJMXReportingEnabled shouldEqual true
+      }
+    }
+
+    "accept contact points with and without port" in {
+      withClusterJ(CassandraConfig(contactPoints = Nel("127.0.0.1:9043", " 127.0.0.2 "))) { _ => () }
+    }
+
+    "reject malformed contact points" in {
+      val error = the[IllegalArgumentException] thrownBy CreateClusterJ(CassandraConfig(contactPoints = Nel("a:b:c")), 1)
+      error.getMessage should include("a:b:c")
+      a[NumberFormatException] should be thrownBy CreateClusterJ(CassandraConfig(contactPoints = Nel("127.0.0.1:port")), 1)
+    }
+  }
+
+  "CassandraClusterOf" should {
+
+    "assign incrementing cluster ids" in {
+      val program = for {
+        clusterOf <- CassandraClusterOf.of[IO]
+        name1 <- clusterOf(CassandraConfig()).use(_.clusterName)
+        name2 <- clusterOf(CassandraConfig()).use(_.clusterName)
+      } yield (name1, name2)
+      program.unsafeRunSync() shouldEqual (("cluster-1", "cluster-2"))
+    }
+
+    "run observe hooks in order of registration" in {
+      val program = for {
+        ref <- Ref[IO].of(List.empty[String])
+        clusterOf <- CassandraClusterOf.of[IO]
+        clusterOf1 = clusterOf
+          .addClusterJObserveHook(cluster => ref.update(_ :+ s"a:${ cluster.getClusterName }"))
+          .addClusterJObserveHook(cluster => ref.update(_ :+ s"b:${ cluster.getClusterName }"))
+        _ <- clusterOf1(CassandraConfig()).use(_ => IO.unit)
+        hooks <- ref.get
+      } yield hooks
+      program.unsafeRunSync() shouldEqual List("a:cluster-1", "b:cluster-1")
+    }
+
+    "remove all observe hooks" in {
+      val program = for {
+        ref <- Ref[IO].of(List.empty[String])
+        clusterOf <- CassandraClusterOf.of[IO]
+        clusterOf1 = clusterOf
+          .addClusterJObserveHook(cluster => ref.update(_ :+ cluster.getClusterName))
+          .removeAllClusterJObserveHooks()
+        _ <- clusterOf1(CassandraConfig()).use(_ => IO.unit)
+        hooks <- ref.get
+      } yield hooks
+      program.unsafeRunSync() shouldEqual Nil
+    }
+  }
+
+  "CassandraCluster" should {
+
+    "expose the cluster name" in {
+      CassandraCluster.of[IO](CassandraConfig(name = "name"), clusterId = 3).use(_.clusterName).unsafeRunSync() shouldEqual "name-3"
+    }
+
+    "mapK" in {
+      val cluster = new CassandraCluster[IO] {
+        def connect: Resource[IO, CassandraSession[IO]] = sys.error("not supported")
+        def connect(keyspace: String): Resource[IO, CassandraSession[IO]] = sys.error("not supported")
+        def clusterName: IO[String] = IO.pure("name")
+        def newSession: Resource[IO, CassandraSession[IO]] = sys.error("not supported")
+        def metadata: IO[Metadata[IO]] = sys.error("not supported")
+      }
+      cluster.mapK(FunctionK.id[IO]).clusterName.unsafeRunSync() shouldEqual "name"
+    }
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
@@ -1,10 +1,19 @@
 package com.evolutiongaming.scassandra
 
-import cats.effect.IO
-import cats.effect.Resource
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
-import com.evolutiongaming.catshelper.Log
+import com.datastax.driver.core.{
+  BoundStatement,
+  CodecRegistry,
+  ColumnDefinitionsMock,
+  ConsistencyLevel,
+  PreparedIdMock,
+  PreparedStatement,
+  ResultSet,
+  Statement,
+}
+import com.evolutiongaming.catshelper.{Log, LogOf}
 import org.scalatest.Succeeded
 import org.scalatest.funsuite.AsyncFunSuite
 
@@ -33,4 +42,135 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
     program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
   }
 
+  test("CassandraHealthCheck#of(statement) reports no error when the statement succeeds") {
+
+    val healthCheck = CassandraHealthCheck.of[IO](
+      initial = 0.seconds,
+      interval = 10.millis,
+      statement = Resource.eval(IO.unit.pure[IO]),
+      log = Log.empty[IO],
+    )
+
+    val program = healthCheck.use { healthCheck =>
+      for {
+        _ <- IO.sleep(100.millis)
+        error <- healthCheck.error
+      } yield assert(error.isEmpty)
+    }
+
+    program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
+  }
+
+  test("CassandraHealthCheck#of(statement) reports no error before the first check") {
+
+    val expectedError = new RuntimeException with NoStackTrace
+
+    val healthCheck = CassandraHealthCheck.of[IO](
+      initial = 1.hour,
+      interval = 1.hour,
+      statement = Resource.eval(expectedError.raiseError[IO, Unit].pure[IO]),
+      log = Log.empty[IO],
+    )
+
+    val program = healthCheck.use(_.error).map { error =>
+      assert(error.isEmpty)
+    }
+
+    program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
+  }
+
+  test("CassandraHealthCheck#of(statement) recovers once the statement succeeds again") {
+
+    val expectedError = new RuntimeException with NoStackTrace
+
+    val program = for {
+      healthy <- Ref[IO].of(false)
+      statement = healthy.get.flatMap { healthy =>
+        if (healthy) IO.unit else expectedError.raiseError[IO, Unit]
+      }
+      healthCheck = CassandraHealthCheck.of[IO](
+        initial = 0.seconds,
+        interval = 10.millis,
+        statement = Resource.eval(statement.pure[IO]),
+        log = Log.empty[IO],
+      )
+      result <- healthCheck.use { healthCheck =>
+        for {
+          error <- healthCheck.error.untilDefinedM
+          _ <- healthy.set(true)
+          recovered <- healthCheck.error.iterateUntil(_.isEmpty)
+        } yield (error, recovered)
+      }
+    } yield {
+      assert(result == ((expectedError, None)))
+    }
+
+    program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
+  }
+
+  test("CassandraHealthCheck.Statement#of prepares system.local query and applies consistency level") {
+
+    val program = for {
+      session <- IO(new SessionMock)
+      statement <- CassandraHealthCheck.Statement.of[IO](session, ConsistencyLevel.LOCAL_QUORUM)
+      _ <- statement
+      executed <- session.executed.get
+    } yield {
+      assert(session.prepared == List("SELECT now() FROM system.local"))
+      assert(executed.map(_.getConsistencyLevel) == List(ConsistencyLevel.LOCAL_QUORUM))
+      assert(executed.map(_.asInstanceOf[BoundStatement].preparedStatement()) ==
+        List(session.preparedStatement))
+    }
+
+    program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
+  }
+
+  test("CassandraHealthCheck#of(session) prepares the statement on acquisition and starts healthy") {
+
+    implicit val logOf: LogOf[IO] = LogOf.empty[IO]
+
+    val program = for {
+      session <- IO(new SessionMock)
+      healthCheck =
+        CassandraHealthCheck.of[IO](Resource.pure[IO, CassandraSession[IO]](session), ConsistencyLevel.ONE)
+      error <- healthCheck.use(_.error)
+      executed <- session.executed.get
+    } yield {
+      assert(session.prepared == List("SELECT now() FROM system.local"))
+      assert(error.isEmpty)
+      assert(executed.isEmpty)
+    }
+
+    program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
+  }
+
+  private class SessionMock extends CassandraSessionMock {
+
+    var prepared: List[String] = Nil
+
+    val executed: Ref[IO, List[Statement]] = Ref.unsafe[IO, List[Statement]](Nil)
+
+    lazy val preparedStatement: PreparedStatement = ProxyMock[PreparedStatement] {
+      case ("getVariables", Nil) => ColumnDefinitionsMock.empty
+      case ("getPreparedId", Nil) => PreparedIdMock.empty
+      case ("getConsistencyLevel", Nil) => null
+      case ("getSerialConsistencyLevel", Nil) => null
+      case ("isTracing", Nil) => Boolean.box(false)
+      case ("getRetryPolicy", Nil) => null
+      case ("getOutgoingPayload", Nil) => null
+      case ("getIncomingPayload", Nil) => null
+      case ("getCodecRegistry", Nil) => CodecRegistry.DEFAULT_INSTANCE
+      case ("isIdempotent", Nil) => null
+      case ("bind", Nil) => new BoundStatement(preparedStatement)
+    }
+
+    override def prepare(query: String): IO[PreparedStatement] = IO {
+      prepared = prepared :+ query
+      preparedStatement
+    }
+
+    override def execute(statement: Statement): IO[ResultSet] = {
+      executed.update(_ :+ statement).as(ResultSetMock())
+    }
+  }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
@@ -128,12 +128,10 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
       healthCheck =
         CassandraHealthCheck.of[IO](Resource.pure[IO, CassandraSession[IO]](session), ConsistencyLevel.ONE)
       error <- healthCheck.use(_.error)
-      executed <- session.executed.get
       prepared <- session.prepared.get
     } yield {
       assert(prepared == List("SELECT now() FROM system.local"))
       assert(error.isEmpty)
-      assert(executed.isEmpty)
     }
 
     program.timeout(10.seconds).as(Succeeded).unsafeToFuture()

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraHealthCheckSpec.scala
@@ -3,16 +3,7 @@ package com.evolutiongaming.scassandra
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
-import com.datastax.driver.core.{
-  BoundStatement,
-  CodecRegistry,
-  ColumnDefinitionsMock,
-  ConsistencyLevel,
-  PreparedIdMock,
-  PreparedStatement,
-  ResultSet,
-  Statement,
-}
+import com.datastax.driver.core.*
 import com.evolutiongaming.catshelper.{Log, LogOf}
 import org.scalatest.Succeeded
 import org.scalatest.funsuite.AsyncFunSuite
@@ -44,19 +35,21 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
 
   test("CassandraHealthCheck#of(statement) reports no error when the statement succeeds") {
 
-    val healthCheck = CassandraHealthCheck.of[IO](
-      initial = 0.seconds,
-      interval = 10.millis,
-      statement = Resource.eval(IO.unit.pure[IO]),
-      log = Log.empty[IO],
-    )
-
-    val program = healthCheck.use { healthCheck =>
-      for {
-        _ <- IO.sleep(100.millis)
-        error <- healthCheck.error
-      } yield assert(error.isEmpty)
-    }
+    val program = for {
+      executions <- Ref[IO].of(0)
+      healthCheck = CassandraHealthCheck.of[IO](
+        initial = 0.seconds,
+        interval = 10.millis,
+        statement = Resource.eval(executions.update(_ + 1).pure[IO]),
+        log = Log.empty[IO],
+      )
+      error <- healthCheck.use { healthCheck =>
+        for {
+          _ <- executions.get.iterateUntil(_ >= 2)
+          error <- healthCheck.error
+        } yield error
+      }
+    } yield assert(error.isEmpty)
 
     program.timeout(10.seconds).as(Succeeded).unsafeToFuture()
   }
@@ -115,8 +108,9 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
       statement <- CassandraHealthCheck.Statement.of[IO](session, ConsistencyLevel.LOCAL_QUORUM)
       _ <- statement
       executed <- session.executed.get
+      prepared <- session.prepared.get
     } yield {
-      assert(session.prepared == List("SELECT now() FROM system.local"))
+      assert(prepared == List("SELECT now() FROM system.local"))
       assert(executed.map(_.getConsistencyLevel) == List(ConsistencyLevel.LOCAL_QUORUM))
       assert(executed.map(_.asInstanceOf[BoundStatement].preparedStatement()) ==
         List(session.preparedStatement))
@@ -135,8 +129,9 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
         CassandraHealthCheck.of[IO](Resource.pure[IO, CassandraSession[IO]](session), ConsistencyLevel.ONE)
       error <- healthCheck.use(_.error)
       executed <- session.executed.get
+      prepared <- session.prepared.get
     } yield {
-      assert(session.prepared == List("SELECT now() FROM system.local"))
+      assert(prepared == List("SELECT now() FROM system.local"))
       assert(error.isEmpty)
       assert(executed.isEmpty)
     }
@@ -146,7 +141,7 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
 
   private class SessionMock extends CassandraSessionMock {
 
-    var prepared: List[String] = Nil
+    val prepared: Ref[IO, List[String]] = Ref.unsafe[IO, List[String]](Nil)
 
     val executed: Ref[IO, List[Statement]] = Ref.unsafe[IO, List[Statement]](Nil)
 
@@ -164,9 +159,8 @@ class CassandraHealthCheckSpec extends AsyncFunSuite {
       case ("bind", Nil) => new BoundStatement(preparedStatement)
     }
 
-    override def prepare(query: String): IO[PreparedStatement] = IO {
-      prepared = prepared :+ query
-      preparedStatement
+    override def prepare(query: String): IO[PreparedStatement] = {
+      prepared.update(_ :+ query).as(preparedStatement)
     }
 
     override def execute(statement: Statement): IO[ResultSet] = {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
@@ -2,25 +2,26 @@ package com.evolutiongaming.scassandra
 
 import cats.effect.IO
 import com.datastax.driver.core.{PreparedStatement, RegularStatement, ResultSet, Statement}
+import com.evolutiongaming.scassandra.MockSupport.notSupported
 
 class CassandraSessionMock extends CassandraSession[IO] {
 
-  def loggedKeyspace: IO[Option[String]] = sys.error("not supported")
+  def loggedKeyspace: IO[Option[String]] = notSupported
 
-  def init: IO[Unit] = sys.error("not supported")
+  def init: IO[Unit] = notSupported
 
-  def execute(query: String): IO[ResultSet] = sys.error("not supported")
+  def execute(query: String): IO[ResultSet] = notSupported
 
-  def execute(query: String, values: Any*): IO[ResultSet] = sys.error("not supported")
+  def execute(query: String, values: Any*): IO[ResultSet] = notSupported
 
-  def execute(query: String, values: Map[String, AnyRef]): IO[ResultSet] = sys.error("not supported")
+  def execute(query: String, values: Map[String, AnyRef]): IO[ResultSet] = notSupported
 
-  def execute(statement: Statement): IO[ResultSet] = sys.error("not supported")
+  def execute(statement: Statement): IO[ResultSet] = notSupported
 
-  def prepare(query: String): IO[PreparedStatement] = sys.error("not supported")
+  def prepare(query: String): IO[PreparedStatement] = notSupported
 
-  def prepare(statement: RegularStatement): IO[PreparedStatement] = sys.error("not supported")
+  def prepare(statement: RegularStatement): IO[PreparedStatement] = notSupported
 
   @deprecated("use stateSnapshot instead", since = "5.6.0")
-  def state: CassandraSession.State[IO] = sys.error("not supported")
+  def state: CassandraSession.State[IO] = notSupported
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
@@ -24,4 +24,6 @@ class CassandraSessionMock extends CassandraSession[IO] {
 
   @deprecated("use stateSnapshot instead", since = "5.6.0")
   def state: CassandraSession.State[IO] = notSupported
+
+  override def stateSnapshot: IO[CassandraSession.StateSnapshot] = notSupported
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionMock.scala
@@ -1,0 +1,26 @@
+package com.evolutiongaming.scassandra
+
+import cats.effect.IO
+import com.datastax.driver.core.{PreparedStatement, RegularStatement, ResultSet, Statement}
+
+class CassandraSessionMock extends CassandraSession[IO] {
+
+  def loggedKeyspace: IO[Option[String]] = sys.error("not supported")
+
+  def init: IO[Unit] = sys.error("not supported")
+
+  def execute(query: String): IO[ResultSet] = sys.error("not supported")
+
+  def execute(query: String, values: Any*): IO[ResultSet] = sys.error("not supported")
+
+  def execute(query: String, values: Map[String, AnyRef]): IO[ResultSet] = sys.error("not supported")
+
+  def execute(statement: Statement): IO[ResultSet] = sys.error("not supported")
+
+  def prepare(query: String): IO[PreparedStatement] = sys.error("not supported")
+
+  def prepare(statement: RegularStatement): IO[PreparedStatement] = sys.error("not supported")
+
+  @deprecated("use stateSnapshot instead", since = "5.6.0")
+  def state: CassandraSession.State[IO] = sys.error("not supported")
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
@@ -22,7 +22,12 @@ import scala.collection.mutable.ListBuffer
 
 class CassandraSessionSpec extends AnyWordSpec with Matchers {
 
-  private def stateJ(hosts: Int, open: Int, trashed: Int, inFlight: Int): SessionJ.State = ProxyMock[SessionJ.State] {
+  private def stateJ(
+    hosts: Int,
+    open: Int,
+    trashed: Int,
+    inFlight: Int,
+  ): SessionJ.State = ProxyMock[SessionJ.State] {
     case ("getConnectedHosts", Nil) => Collections.nCopies(hosts, null: Host)
     case ("getOpenConnections", _) => Int.box(open)
     case ("getTrashedConnections", _) => Int.box(trashed)
@@ -169,7 +174,7 @@ class CassandraSessionSpec extends AnyWordSpec with Matchers {
   "CassandraSession.State" should {
 
     "wrap the driver state" in {
-      val state = (CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation"))
+      val state = CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation")
       state.connectedHosts.unsafeRunSync().size shouldEqual 1
       state.openConnections(null).unsafeRunSync() shouldEqual 2
       state.trashedConnections(null).unsafeRunSync() shouldEqual 3
@@ -177,7 +182,8 @@ class CassandraSessionSpec extends AnyWordSpec with Matchers {
     }
 
     "mapK" in {
-      val state = (CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation")).mapK(FunctionK.id[IO])
+      val state =
+        (CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation")).mapK(FunctionK.id[IO])
       state.connectedHosts.unsafeRunSync().size shouldEqual 1
       state.openConnections(null).unsafeRunSync() shouldEqual 2
       state.trashedConnections(null).unsafeRunSync() shouldEqual 3

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
@@ -1,0 +1,187 @@
+package com.evolutiongaming.scassandra
+
+import cats.arrow.FunctionK
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.~>
+import com.datastax.driver.core.{
+  CloseFutureMock,
+  Host,
+  PreparedStatement,
+  ResultSet,
+  Session as SessionJ,
+  SimpleStatement,
+}
+import com.google.common.util.concurrent.Futures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.{Collections, Map as MapJ}
+import scala.annotation.nowarn
+import scala.collection.mutable.ListBuffer
+
+class CassandraSessionSpec extends AnyWordSpec with Matchers {
+
+  private def stateJ(hosts: Int, open: Int, trashed: Int, inFlight: Int): SessionJ.State = ProxyMock[SessionJ.State] {
+    case ("getConnectedHosts", Nil) => Collections.nCopies(hosts, null: Host)
+    case ("getOpenConnections", _) => Int.box(open)
+    case ("getTrashedConnections", _) => Int.box(trashed)
+    case ("getInFlightQueries", _) => Int.box(inFlight)
+  }
+
+  private class SessionStub(
+    resultSet: ResultSet = ResultSetMock(),
+    prepared: PreparedStatement = ProxyMock[PreparedStatement](PartialFunction.empty),
+    states: List[SessionJ.State] = List(stateJ(1, 1, 0, 0)),
+    keyspace: String = null,
+  ) {
+    val calls: ListBuffer[(String, List[AnyRef])] = ListBuffer.empty
+    private val statesLeft = Iterator.continually(states).flatten
+
+    lazy val sessionJ: SessionJ = ProxyMock[SessionJ] {
+      case ("getLoggedKeyspace", Nil) => keyspace
+      case ("initAsync", Nil) => calls += (("initAsync", Nil)); Futures.immediateFuture(sessionJ)
+      case ("executeAsync", args) => calls += (("executeAsync", args)); ResultSetFutureMock(resultSet)
+      case ("prepareAsync", args) => calls += (("prepareAsync", args)); Futures.immediateFuture(prepared)
+      case ("closeAsync", Nil) => calls += (("closeAsync", Nil)); CloseFutureMock()
+      case ("getState", Nil) => statesLeft.next()
+    }
+
+    lazy val session: CassandraSession[IO] = CassandraSession[IO](sessionJ)
+  }
+
+  "CassandraSession" should {
+
+    "loggedKeyspace" in {
+      new SessionStub().session.loggedKeyspace.unsafeRunSync() shouldEqual None
+      new SessionStub(keyspace = "ks").session.loggedKeyspace.unsafeRunSync() shouldEqual Some("ks")
+    }
+
+    "init" in {
+      val stub = new SessionStub()
+      stub.session.init.unsafeRunSync()
+      stub.calls.toList shouldEqual List(("initAsync", Nil))
+    }
+
+    "execute query" in {
+      val resultSet = ResultSetMock()
+      val stub = new SessionStub(resultSet = resultSet)
+      stub.session.execute("SELECT 1").unsafeRunSync() shouldBe theSameInstanceAs(resultSet)
+      stub.calls.toList shouldEqual List(("executeAsync", List("SELECT 1")))
+    }
+
+    "execute query with positional values" in {
+      val stub = new SessionStub()
+      stub.session.execute("SELECT ?, ?", "a", 1).unsafeRunSync()
+      val (name, args) = stub.calls.head
+      name shouldEqual "executeAsync"
+      args.head shouldEqual "SELECT ?, ?"
+      args(1).asInstanceOf[Array[AnyRef]].toList shouldEqual List("a", Int.box(1))
+    }
+
+    "execute query with named values" in {
+      val stub = new SessionStub()
+      stub.session.execute("SELECT :a", Map[String, AnyRef]("a" -> "b")).unsafeRunSync()
+      val (name, args) = stub.calls.head
+      name shouldEqual "executeAsync"
+      args.head shouldEqual "SELECT :a"
+      args(1).asInstanceOf[MapJ[String, AnyRef]].get("a") shouldEqual "b"
+    }
+
+    "execute statement" in {
+      val stub = new SessionStub()
+      val statement = new SimpleStatement("SELECT 1")
+      stub.session.execute(statement).unsafeRunSync()
+      stub.calls.head shouldEqual (("executeAsync", List(statement)))
+    }
+
+    "prepare query" in {
+      val prepared = ProxyMock[PreparedStatement](PartialFunction.empty)
+      val stub = new SessionStub(prepared = prepared)
+      stub.session.prepare("SELECT 1").unsafeRunSync() shouldBe theSameInstanceAs(prepared)
+      stub.calls.toList shouldEqual List(("prepareAsync", List("SELECT 1")))
+    }
+
+    "prepare statement" in {
+      val stub = new SessionStub()
+      val statement = new SimpleStatement("SELECT 1")
+      stub.session.prepare(statement).unsafeRunSync()
+      stub.calls.head shouldEqual (("prepareAsync", List(statement)))
+    }
+
+    "stateSnapshot" in {
+      val stub = new SessionStub(states = List(stateJ(2, 3, 4, 5)))
+      val snapshot = stub.session.stateSnapshot.unsafeRunSync()
+      snapshot.connectedHosts.size shouldEqual 2
+      snapshot.openConnections(null) shouldEqual 3
+      snapshot.trashedConnections(null) shouldEqual 4
+      snapshot.inFlightQueries(null) shouldEqual 5
+    }
+
+    "state takes a fresh snapshot on every access" in {
+      val stub = new SessionStub(states = List(stateJ(0, 0, 0, 0), stateJ(2, 1, 0, 0)))
+      val state = stub.session.state: @nowarn("cat=deprecation")
+      state.connectedHosts.unsafeRunSync().size shouldEqual 0
+      state.connectedHosts.unsafeRunSync().size shouldEqual 2
+    }
+
+    "of closes the session on release" in {
+      val stub = new SessionStub()
+      CassandraSession.of[IO](IO(stub.sessionJ)).use(_.init).unsafeRunSync()
+      stub.calls.toList shouldEqual List(("initAsync", Nil), ("closeAsync", Nil))
+    }
+
+    "mapK" in {
+      val stub = new SessionStub()
+      val program = for {
+        counter <- Ref[IO].of(0)
+        counting = new (IO ~> IO) {
+          def apply[A](fa: IO[A]): IO[A] = counter.update(_ + 1) *> fa
+        }
+        session = stub.session.mapK(counting)
+        _ <- session.init
+        _ <- session.execute("q")
+        _ <- session.execute("q", "a")
+        _ <- session.execute("q", Map.empty[String, AnyRef])
+        _ <- session.execute(new SimpleStatement("q"))
+        _ <- session.prepare("q")
+        _ <- session.prepare(new SimpleStatement("q"))
+        _ <- session.loggedKeyspace
+        _ <- session.stateSnapshot
+        _ <- (session.state: @nowarn("cat=deprecation")).connectedHosts
+        count <- counter.get
+      } yield count
+      program.unsafeRunSync() shouldEqual 10
+    }
+  }
+
+  "CassandraSession.StateSnapshot" should {
+
+    "wrap the driver state" in {
+      val snapshot = CassandraSession.StateSnapshot.wrapImmutable(stateJ(1, 2, 3, 4))
+      snapshot.connectedHosts.size shouldEqual 1
+      snapshot.openConnections(null) shouldEqual 2
+      snapshot.trashedConnections(null) shouldEqual 3
+      snapshot.inFlightQueries(null) shouldEqual 4
+    }
+  }
+
+  "CassandraSession.State" should {
+
+    "wrap the driver state" in {
+      val state = (CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation"))
+      state.connectedHosts.unsafeRunSync().size shouldEqual 1
+      state.openConnections(null).unsafeRunSync() shouldEqual 2
+      state.trashedConnections(null).unsafeRunSync() shouldEqual 3
+      state.inFlightQueries(null).unsafeRunSync() shouldEqual 4
+    }
+
+    "mapK" in {
+      val state = (CassandraSession.State[IO](stateJ(1, 2, 3, 4)): @nowarn("cat=deprecation")).mapK(FunctionK.id[IO])
+      state.connectedHosts.unsafeRunSync().size shouldEqual 1
+      state.openConnections(null).unsafeRunSync() shouldEqual 2
+      state.trashedConnections(null).unsafeRunSync() shouldEqual 3
+      state.inFlightQueries(null).unsafeRunSync() shouldEqual 4
+    }
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CassandraSessionSpec.scala
@@ -22,6 +22,8 @@ import scala.collection.mutable.ListBuffer
 
 class CassandraSessionSpec extends AnyWordSpec with Matchers {
 
+  private val query = "SELECT 1"
+
   private def stateJ(
     hosts: Int,
     open: Int,
@@ -71,8 +73,8 @@ class CassandraSessionSpec extends AnyWordSpec with Matchers {
     "execute query" in {
       val resultSet = ResultSetMock()
       val stub = new SessionStub(resultSet = resultSet)
-      stub.session.execute("SELECT 1").unsafeRunSync() shouldBe theSameInstanceAs(resultSet)
-      stub.calls.toList shouldEqual List(("executeAsync", List("SELECT 1")))
+      stub.session.execute(query).unsafeRunSync() shouldBe theSameInstanceAs(resultSet)
+      stub.calls.toList shouldEqual List(("executeAsync", List(query)))
     }
 
     "execute query with positional values" in {
@@ -95,7 +97,7 @@ class CassandraSessionSpec extends AnyWordSpec with Matchers {
 
     "execute statement" in {
       val stub = new SessionStub()
-      val statement = new SimpleStatement("SELECT 1")
+      val statement = new SimpleStatement(query)
       stub.session.execute(statement).unsafeRunSync()
       stub.calls.head shouldEqual (("executeAsync", List(statement)))
     }
@@ -103,13 +105,13 @@ class CassandraSessionSpec extends AnyWordSpec with Matchers {
     "prepare query" in {
       val prepared = ProxyMock[PreparedStatement](PartialFunction.empty)
       val stub = new SessionStub(prepared = prepared)
-      stub.session.prepare("SELECT 1").unsafeRunSync() shouldBe theSameInstanceAs(prepared)
-      stub.calls.toList shouldEqual List(("prepareAsync", List("SELECT 1")))
+      stub.session.prepare(query).unsafeRunSync() shouldBe theSameInstanceAs(prepared)
+      stub.calls.toList shouldEqual List(("prepareAsync", List(query)))
     }
 
     "prepare statement" in {
       val stub = new SessionStub()
-      val statement = new SimpleStatement("SELECT 1")
+      val statement = new SimpleStatement(query)
       stub.session.prepare(statement).unsafeRunSync()
       stub.calls.head shouldEqual (("prepareAsync", List(statement)))
     }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
@@ -1,0 +1,37 @@
+package com.evolutiongaming.scassandra
+
+import com.evolutiongaming.config.ConfigHelper.*
+import com.evolutiongaming.nel.Nel
+import com.evolutiongaming.scassandra.ConfigHelpers.*
+import com.typesafe.config.{ConfigException, ConfigFactory}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pureconfig.ConfigSource
+import pureconfig.error.ConvertFailure
+import pureconfig.module.cats.EmptyTraversableFound
+
+class ConfigHelpersSpec extends AnyFunSuite with Matchers {
+
+  test("nelFromConf reads a non-empty list") {
+    ConfigFactory.parseString("""a = ["x", "y"]""").getOpt[Nel[String]]("a") shouldEqual Some(Nel("x", "y"))
+  }
+
+  test("nelFromConf returns None for a missing path") {
+    ConfigFactory.empty().getOpt[Nel[String]]("a") shouldEqual None
+  }
+
+  test("nelFromConf fails on an empty list") {
+    a[ConfigException.BadValue] should be thrownBy ConfigFactory.parseString("a = []").getOpt[Nel[String]]("a")
+  }
+
+  test("nelReader reads a non-empty list") {
+    ConfigSource.string("""a = ["x", "y"]""").at("a").load[Nel[String]] shouldEqual Right(Nel("x", "y"))
+  }
+
+  test("nelReader fails on an empty list") {
+    val failures = ConfigSource.string("a = []").at("a").load[Nel[String]].swap.toOption.get
+    val reasons = failures.toList.collect { case ConvertFailure(reason, _, _) => reason }
+    reasons should have size 1
+    reasons.head shouldBe a[EmptyTraversableFound]
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
@@ -4,13 +4,14 @@ import com.evolutiongaming.config.ConfigHelper.*
 import com.evolutiongaming.nel.Nel
 import com.evolutiongaming.scassandra.ConfigHelpers.*
 import com.typesafe.config.{ConfigException, ConfigFactory}
+import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 import pureconfig.error.ConvertFailure
 import pureconfig.module.cats.EmptyTraversableFound
 
-class ConfigHelpersSpec extends AnyFunSuite with Matchers {
+class ConfigHelpersSpec extends AnyFunSuite with Matchers with EitherValues {
 
   test("nelFromConf reads a non-empty list") {
     ConfigFactory.parseString("""a = ["x", "y"]""").getOpt[Nel[String]]("a") shouldEqual Some(Nel("x", "y"))
@@ -30,7 +31,7 @@ class ConfigHelpersSpec extends AnyFunSuite with Matchers {
   }
 
   test("nelReader fails on an empty list") {
-    val failures = ConfigSource.string("a = []").at("a").load[Nel[String]].swap.toOption.get
+    val failures = ConfigSource.string("a = []").at("a").load[Nel[String]].left.value
     val reasons = failures.toList.collect { case ConvertFailure(reason, _, _) => reason }
     reasons should have size 1
     reasons.head shouldBe a[EmptyTraversableFound]

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigHelpersSpec.scala
@@ -21,7 +21,8 @@ class ConfigHelpersSpec extends AnyFunSuite with Matchers {
   }
 
   test("nelFromConf fails on an empty list") {
-    a[ConfigException.BadValue] should be thrownBy ConfigFactory.parseString("a = []").getOpt[Nel[String]]("a")
+    a[ConfigException.BadValue] should be thrownBy
+      ConfigFactory.parseString("a = []").getOpt[Nel[String]]("a")
   }
 
   test("nelReader reads a non-empty list") {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigReaderFromEnumSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigReaderFromEnumSpec.scala
@@ -3,13 +3,14 @@ package com.evolutiongaming.scassandra
 import com.datastax.driver.core.ProtocolVersion
 import com.evolutiongaming.scassandra.util.ConfigReaderFromEnum
 import com.typesafe.config.ConfigValueFactory
+import org.scalatest.EitherValues
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.error.CannotParse
 
 import scala.jdk.CollectionConverters.*
 
-class ConfigReaderFromEnumSpec extends AnyFunSuite with Matchers {
+class ConfigReaderFromEnumSpec extends AnyFunSuite with Matchers with EitherValues {
 
   private val reader = ConfigReaderFromEnum(ProtocolVersion.values())
 
@@ -23,7 +24,7 @@ class ConfigReaderFromEnumSpec extends AnyFunSuite with Matchers {
   }
 
   test("fail on unknown name") {
-    val failure = reader.from(ConfigValueFactory.fromAnyRef("V0")).swap.toOption.get.toList.head
+    val failure = reader.from(ConfigValueFactory.fromAnyRef("V0")).left.value.toList.head
     failure shouldBe a[CannotParse]
     failure.description should include("ProtocolVersion")
     failure.description should include("V0")

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigReaderFromEnumSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ConfigReaderFromEnumSpec.scala
@@ -1,0 +1,35 @@
+package com.evolutiongaming.scassandra
+
+import com.datastax.driver.core.ProtocolVersion
+import com.evolutiongaming.scassandra.util.ConfigReaderFromEnum
+import com.typesafe.config.ConfigValueFactory
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pureconfig.error.CannotParse
+
+import scala.jdk.CollectionConverters.*
+
+class ConfigReaderFromEnumSpec extends AnyFunSuite with Matchers {
+
+  private val reader = ConfigReaderFromEnum(ProtocolVersion.values())
+
+  test("read exact name") {
+    reader.from(ConfigValueFactory.fromAnyRef("V4")) shouldEqual Right(ProtocolVersion.V4)
+  }
+
+  test("read ignoring case") {
+    reader.from(ConfigValueFactory.fromAnyRef("v4")) shouldEqual Right(ProtocolVersion.V4)
+    reader.from(ConfigValueFactory.fromAnyRef("v3")) shouldEqual Right(ProtocolVersion.V3)
+  }
+
+  test("fail on unknown name") {
+    val failure = reader.from(ConfigValueFactory.fromAnyRef("V0")).swap.toOption.get.toList.head
+    failure shouldBe a[CannotParse]
+    failure.description should include("ProtocolVersion")
+    failure.description should include("V0")
+  }
+
+  test("fail on non-string value") {
+    reader.from(ConfigValueFactory.fromMap(Map("a" -> "b").asJava)).isLeft shouldEqual true
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CreateKeyspaceIfNotExistsSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CreateKeyspaceIfNotExistsSpec.scala
@@ -1,0 +1,31 @@
+package com.evolutiongaming.scassandra
+
+import com.evolutiongaming.nel.Nel
+import com.evolutiongaming.scassandra.ReplicationStrategyConfig.{NetworkTopology, Simple}
+import com.evolutiongaming.scassandra.syntax.*
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class CreateKeyspaceIfNotExistsSpec extends AnyFunSuite with Matchers {
+
+  test("simple strategy") {
+    CreateKeyspaceIfNotExists("ks", Simple(2)) shouldEqual
+      "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':2 }"
+  }
+
+  test("network topology strategy") {
+    val strategy = NetworkTopology(Nel(NetworkTopology.DcFactor("dc1", 2), NetworkTopology.DcFactor("dc2", 3)))
+    CreateKeyspaceIfNotExists("ks", strategy) shouldEqual
+      "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy','dc1':2,'dc2':3 }"
+  }
+
+  test("default strategy") {
+    CreateKeyspaceIfNotExists("ks", ReplicationStrategyConfig.Default) shouldEqual
+      "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':1 }"
+  }
+
+  test("TableName.toCql") {
+    TableName("ks", "table").toCql shouldEqual "ks.table"
+    ToCql[TableName].apply(TableName("ks", "table")) shouldEqual "ks.table"
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/CreateKeyspaceIfNotExistsSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/CreateKeyspaceIfNotExistsSpec.scala
@@ -14,7 +14,8 @@ class CreateKeyspaceIfNotExistsSpec extends AnyFunSuite with Matchers {
   }
 
   test("network topology strategy") {
-    val strategy = NetworkTopology(Nel(NetworkTopology.DcFactor("dc1", 2), NetworkTopology.DcFactor("dc2", 3)))
+    val strategy =
+      NetworkTopology(Nel(NetworkTopology.DcFactor("dc1", 2), NetworkTopology.DcFactor("dc2", 3)))
     CreateKeyspaceIfNotExists("ks", strategy) shouldEqual
       "CREATE KEYSPACE IF NOT EXISTS ks WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy','dc1':2,'dc2':3 }"
   }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/DataMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/DataMock.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.scassandra
 
 import com.datastax.driver.core.*
+import com.evolutiongaming.scassandra.MockSupport.notSupported
 import com.google.common.reflect.TypeToken
 
 import java.math.{BigDecimal as BigDecimalJ, BigInteger}
@@ -14,8 +15,6 @@ case class DataMock(
   byName: Map[String, Any] = Map.empty,
   byIdx: Map[Int, Any] = Map.empty,
 ) extends SettableData[DataMock] with GettableData {
-
-  private def notSupported() = sys.error("not support")
 
   override def setBool(i: Int, v: Boolean): DataMock = copy(byIdx = byIdx.updated(i, v))
   override def setByte(i: Int, v: Byte): DataMock = copy(byIdx = byIdx.updated(i, v))
@@ -35,21 +34,21 @@ case class DataMock(
   override def setUUID(i: Int, v: UUID): DataMock = copy(byIdx = byIdx.updated(i, v))
   override def setInet(i: Int, v: InetAddress): DataMock = copy(byIdx = byIdx.updated(i, v))
   override def setList[E](i: Int, v: ListJ[E]): DataMock = copy(byIdx = byIdx.updated(i, v))
-  override def setList[E](i: Int, v: ListJ[E], elementsClass: Class[E]): DataMock = notSupported()
-  override def setList[E](i: Int, v: ListJ[E], elementsType: TypeToken[E]): DataMock = notSupported()
+  override def setList[E](i: Int, v: ListJ[E], elementsClass: Class[E]): DataMock = notSupported
+  override def setList[E](i: Int, v: ListJ[E], elementsType: TypeToken[E]): DataMock = notSupported
   override def setMap[K, V](i: Int, v: MapJ[K, V]): DataMock = copy(byIdx = byIdx.updated(i, v))
   override def setMap[K, V](
     i: Int,
     v: MapJ[K, V],
     keysClass: Class[K],
     valuesClass: Class[V],
-  ): DataMock = notSupported()
+  ): DataMock = notSupported
   override def setMap[K, V](
     i: Int,
     v: MapJ[K, V],
     keysType: TypeToken[K],
     valuesType: TypeToken[V],
-  ): DataMock = notSupported()
+  ): DataMock = notSupported
   override def setSet[E](i: Int, v: SetJ[E]): DataMock = copy(byIdx = byIdx.updated(i, v))
   override def setSet[E](i: Int, v: SetJ[E], elementsClass: Class[E]): DataMock =
     copy(byIdx = byIdx.updated(i, v))
@@ -132,20 +131,20 @@ case class DataMock(
   override def getDecimal(name: String): BigDecimalJ = byName.getOrElse(name, null).asInstanceOf[BigDecimalJ]
   override def getUUID(name: String): UUID = byName.getOrElse(name, null).asInstanceOf[UUID]
   override def getInet(name: String): InetAddress = byName.getOrElse(name, null).asInstanceOf[InetAddress]
-  override def getList[T](name: String, elementsClass: Class[T]): ListJ[T] = notSupported()
-  override def getList[T](name: String, elementsType: TypeToken[T]): ListJ[T] = notSupported()
+  override def getList[T](name: String, elementsClass: Class[T]): ListJ[T] = notSupported
+  override def getList[T](name: String, elementsType: TypeToken[T]): ListJ[T] = notSupported
   override def getSet[T](name: String, elementsClass: Class[T]): SetJ[T] =
     byName.getOrElse(name, null).asInstanceOf[SetJ[T]]
-  override def getSet[T](name: String, elementsType: TypeToken[T]): SetJ[T] = notSupported()
+  override def getSet[T](name: String, elementsType: TypeToken[T]): SetJ[T] = notSupported
   override def getMap[K, V](name: String, keysClass: Class[K], valuesClass: Class[V]): MapJ[K, V] =
-    notSupported()
+    notSupported
   override def getMap[K, V](name: String, keysType: TypeToken[K], valuesType: TypeToken[V]): MapJ[K, V] =
-    notSupported()
-  override def getUDTValue(name: String): UDTValue = notSupported()
-  override def getTupleValue(name: String): TupleValue = notSupported()
-  override def getObject(name: String): Object = notSupported()
-  override def get[T](name: String, targetClass: Class[T]): T = notSupported()
-  override def get[T](name: String, targetType: TypeToken[T]): T = notSupported()
+    notSupported
+  override def getUDTValue(name: String): UDTValue = notSupported
+  override def getTupleValue(name: String): TupleValue = notSupported
+  override def getObject(name: String): Object = notSupported
+  override def get[T](name: String, targetClass: Class[T]): T = notSupported
+  override def get[T](name: String, targetType: TypeToken[T]): T = notSupported
   override def get[T](name: String, codec: TypeCodec[T]): T = byName.getOrElse(name, null).asInstanceOf[T]
 
   override def isNull(i: Int): Boolean = !byIdx.contains(i)
@@ -166,19 +165,19 @@ case class DataMock(
   override def getDecimal(i: Int): BigDecimalJ = byIdx.getOrElse(i, null).asInstanceOf[BigDecimalJ]
   override def getUUID(i: Int): UUID = byIdx.getOrElse(i, null).asInstanceOf[UUID]
   override def getInet(i: Int): InetAddress = byIdx.getOrElse(i, null).asInstanceOf[InetAddress]
-  override def getList[T](i: Int, elementsClass: Class[T]): ListJ[T] = notSupported()
-  override def getList[T](i: Int, elementsType: TypeToken[T]): ListJ[T] = notSupported()
+  override def getList[T](i: Int, elementsClass: Class[T]): ListJ[T] = notSupported
+  override def getList[T](i: Int, elementsType: TypeToken[T]): ListJ[T] = notSupported
   override def getSet[T](i: Int, elementsClass: Class[T]): SetJ[T] =
     byIdx.getOrElse(i, null).asInstanceOf[SetJ[T]]
   override def getSet[T](i: Int, elementsType: TypeToken[T]): SetJ[T] =
     byIdx.getOrElse(i, null).asInstanceOf[SetJ[T]]
-  override def getMap[K, V](i: Int, keysClass: Class[K], valuesClass: Class[V]): MapJ[K, V] = notSupported()
+  override def getMap[K, V](i: Int, keysClass: Class[K], valuesClass: Class[V]): MapJ[K, V] = notSupported
   override def getMap[K, V](i: Int, keysType: TypeToken[K], valuesType: TypeToken[V]): MapJ[K, V] =
-    notSupported()
-  override def getUDTValue(i: Int): UDTValue = notSupported()
-  override def getTupleValue(i: Int): TupleValue = notSupported()
-  override def getObject(i: Int): Object = notSupported()
-  override def get[T](i: Int, targetClass: Class[T]): T = notSupported()
-  override def get[T](i: Int, targetType: TypeToken[T]): T = notSupported()
+    notSupported
+  override def getUDTValue(i: Int): UDTValue = notSupported
+  override def getTupleValue(i: Int): TupleValue = notSupported
+  override def getObject(i: Int): Object = notSupported
+  override def get[T](i: Int, targetClass: Class[T]): T = notSupported
+  override def get[T](i: Int, targetType: TypeToken[T]): T = notSupported
   override def get[T](i: Int, codec: TypeCodec[T]): T = byIdx.getOrElse(i, null).asInstanceOf[T]
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
@@ -1,0 +1,72 @@
+package com.evolutiongaming.scassandra
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.evolutiongaming.scassandra.util.FromGFuture
+import com.google.common.util.concurrent.{Futures, SettableFuture}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.util.concurrent.Executor
+import scala.annotation.nowarn
+import scala.concurrent.duration.*
+import scala.util.control.NoStackTrace
+
+class FromGFutureSpec extends AnyFunSuite with Matchers {
+
+  test("completed future") {
+    FromGFuture[IO].apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
+  }
+
+  test("failed future") {
+    val error = new RuntimeException("boom") with NoStackTrace
+    FromGFuture[IO].apply(Futures.immediateFailedFuture[Int](error)).attempt.unsafeRunSync() shouldEqual Left(error)
+  }
+
+  test("future is created lazily and on every run") {
+    var created = 0
+    val io = FromGFuture[IO].apply {
+      created += 1
+      Futures.immediateFuture(created)
+    }
+    created shouldEqual 0
+    io.unsafeRunSync() shouldEqual 1
+    io.unsafeRunSync() shouldEqual 2
+  }
+
+  test("future completed later") {
+    val future = SettableFuture.create[Int]()
+    val program = for {
+      fiber <- FromGFuture[IO].apply(future).start
+      _ <- IO(future.set(42))
+      a <- fiber.joinWithNever
+    } yield a
+    program.unsafeRunSync() shouldEqual 42
+  }
+
+  test("future is cancelled when F is cancelled") {
+    val future = SettableFuture.create[Int]()
+    val program = for {
+      fiber <- FromGFuture[IO].apply(future).start
+      _ <- IO.sleep(100.millis)
+      _ <- fiber.cancel
+    } yield ()
+    program.unsafeRunSync()
+    future.isCancelled shouldEqual true
+  }
+
+  test("fromExecutor runs the callback on the provided executor") {
+    var runs = 0
+    val executor: Executor = runnable => {
+      runs += 1
+      runnable.run()
+    }
+    FromGFuture.fromExecutor[IO](executor).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
+    runs shouldEqual 1
+  }
+
+  test("deprecated lift") {
+    implicit val executor: Executor = _.run()
+    (FromGFuture.lift[IO]: @nowarn("cat=deprecation")).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
@@ -8,6 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.util.concurrent.Executor
+import java.util.concurrent.atomic.AtomicInteger
 import scala.annotation.nowarn
 import scala.concurrent.duration.*
 import scala.util.control.NoStackTrace
@@ -25,12 +26,11 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
   }
 
   test("future is created lazily and on every run") {
-    var created = 0
+    val created = new AtomicInteger(0)
     val io = FromGFuture[IO].apply {
-      created += 1
-      Futures.immediateFuture(created)
+      Futures.immediateFuture(created.incrementAndGet())
     }
-    created shouldEqual 0
+    created.get() shouldEqual 0
     io.unsafeRunSync() shouldEqual 1
     io.unsafeRunSync() shouldEqual 2
   }
@@ -57,13 +57,13 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
   }
 
   test("fromExecutor runs the callback on the provided executor") {
-    var runs = 0
+    val runs = new AtomicInteger(0)
     val executor: Executor = runnable => {
-      runs += 1
+      runs.incrementAndGet()
       runnable.run()
     }
     FromGFuture.fromExecutor[IO](executor).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
-    runs shouldEqual 1
+    runs.get() shouldEqual 1
   }
 
   test("deprecated lift") {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
@@ -3,14 +3,13 @@ package com.evolutiongaming.scassandra
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.evolutiongaming.scassandra.util.FromGFuture
-import com.google.common.util.concurrent.{Futures, SettableFuture}
+import com.google.common.util.concurrent.{AbstractFuture, Futures, SettableFuture}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.{CountDownLatch, Executor}
 import scala.annotation.nowarn
-import scala.concurrent.duration.*
 import scala.util.control.NoStackTrace
 
 class FromGFutureSpec extends AnyFunSuite with Matchers {
@@ -46,10 +45,10 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
   }
 
   test("future is cancelled when F is cancelled") {
-    val future = SettableFuture.create[Int]()
+    val future = new ObservableFuture
     val program = for {
       fiber <- FromGFuture[IO].apply(future).start
-      _ <- IO.sleep(100.millis)
+      _ <- IO.interruptible(future.listenerAdded.await())
       _ <- fiber.cancel
     } yield ()
     program.unsafeRunSync()
@@ -64,6 +63,16 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
     }
     FromGFuture.fromExecutor[IO](executor).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
     runs.get() shouldEqual 1
+  }
+
+  private class ObservableFuture extends AbstractFuture[Int] {
+
+    val listenerAdded = new CountDownLatch(1)
+
+    override def addListener(listener: Runnable, executor: Executor): Unit = {
+      super.addListener(listener, executor)
+      listenerAdded.countDown()
+    }
   }
 
   test("deprecated lift") {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/FromGFutureSpec.scala
@@ -20,7 +20,8 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
 
   test("failed future") {
     val error = new RuntimeException("boom") with NoStackTrace
-    FromGFuture[IO].apply(Futures.immediateFailedFuture[Int](error)).attempt.unsafeRunSync() shouldEqual Left(error)
+    FromGFuture[IO].apply(Futures.immediateFailedFuture[Int](error)).attempt.unsafeRunSync() shouldEqual
+      Left(error)
   }
 
   test("future is created lazily and on every run") {
@@ -67,6 +68,8 @@ class FromGFutureSpec extends AnyFunSuite with Matchers {
 
   test("deprecated lift") {
     implicit val executor: Executor = _.run()
-    (FromGFuture.lift[IO]: @nowarn("cat=deprecation")).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
+    (FromGFuture.lift[IO]: @nowarn(
+      "cat=deprecation",
+    )).apply(Futures.immediateFuture(1)).unsafeRunSync() shouldEqual 1
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/LoadBalancingConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/LoadBalancingConfigSpec.scala
@@ -1,10 +1,13 @@
 package com.evolutiongaming.scassandra
 
 import cats.implicits.*
+import com.datastax.driver.core.policies.{DCAwareRoundRobinPolicy, TokenAwarePolicy}
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
+
+import scala.annotation.nowarn
 
 class LoadBalancingConfigSpec extends AnyFunSuite with Matchers {
 
@@ -20,5 +23,29 @@ class LoadBalancingConfigSpec extends AnyFunSuite with Matchers {
       allowRemoteDcsForLocalConsistencyLevel = true,
     )
     ConfigSource.fromConfig(config).load[LoadBalancingConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava wraps a DC aware policy into a token aware one") {
+    val policy = LoadBalancingConfig(localDc = "dc1").asJava
+    policy.map(_.getClass) shouldEqual Some(classOf[TokenAwarePolicy])
+    policy.map(_.asInstanceOf[TokenAwarePolicy].getChildPolicy.getClass) shouldEqual
+      Some(classOf[DCAwareRoundRobinPolicy])
+  }
+
+  test("asJava is None for an empty local DC") {
+    LoadBalancingConfig(localDc = "").asJava shouldEqual None
+  }
+
+  test("fromConfig falls back to default on invalid config") {
+    val config = ConfigFactory.parseString("allow-remote-dcs-for-local-consistency-level = nope")
+    LoadBalancingConfig.fromConfig(config, LoadBalancingConfig.Default) shouldEqual
+      LoadBalancingConfig.Default
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("local-dc = dc1")
+    (LoadBalancingConfig(config): @nowarn("cat=deprecation")) shouldEqual LoadBalancingConfig(localDc = "dc1")
+    (LoadBalancingConfig(config, LoadBalancingConfig.Default): @nowarn("cat=deprecation")) shouldEqual
+      LoadBalancingConfig(localDc = "dc1")
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MaskedSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MaskedSpec.scala
@@ -1,0 +1,24 @@
+package com.evolutiongaming.scassandra
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import pureconfig.ConfigSource
+
+class MaskedSpec extends AnyFunSuite with Matchers {
+
+  test("toString hides the value") {
+    Masked("secret").toString shouldEqual "***"
+    s"${ Masked("secret") }" shouldEqual "***"
+    Masked("secret").value shouldEqual "secret"
+  }
+
+  test("equality is by value") {
+    Masked("a") shouldEqual Masked("a")
+    Masked("a") should not equal Masked("b")
+  }
+
+  test("read from config") {
+    ConfigSource.string("password = secret").at("password").load[Masked[String]] shouldEqual Right(Masked("secret"))
+    ConfigSource.string("port = 1").at("port").load[Masked[Int]] shouldEqual Right(Masked(1))
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MaskedSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MaskedSpec.scala
@@ -18,7 +18,8 @@ class MaskedSpec extends AnyFunSuite with Matchers {
   }
 
   test("read from config") {
-    ConfigSource.string("password = secret").at("password").load[Masked[String]] shouldEqual Right(Masked("secret"))
+    ConfigSource.string("password = secret").at("password").load[Masked[String]] shouldEqual
+      Right(Masked("secret"))
     ConfigSource.string("port = 1").at("port").load[Masked[Int]] shouldEqual Right(Masked(1))
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
@@ -27,7 +27,8 @@ class MetadataSpec extends AnyWordSpec with Matchers {
 
   private val metadata: Metadata[IO] = new Metadata[IO] {
     def clusterName: IO[String] = IO.pure("cluster")
-    def keyspace(name: String): IO[Option[KeyspaceMetadata[IO]]] = IO.pure(Option.when(name == "keyspace")(keyspaceMetadata))
+    def keyspace(name: String): IO[Option[KeyspaceMetadata[IO]]] =
+      IO.pure(Option.when(name == "keyspace")(keyspaceMetadata))
     def keyspaces: IO[List[KeyspaceMetadata[IO]]] = IO.pure(List(keyspaceMetadata))
     def schema: IO[String] = IO.pure("schema")
   }
@@ -49,8 +50,17 @@ class MetadataSpec extends AnyWordSpec with Matchers {
         keyspaces <- metadata1.keyspaces
         keyspaceSchema <- keyspace.get.schema
         count <- counter.get
-      } yield (clusterName, schema, keyspace.map(_.name), missing, keyspaces.map(_.name), keyspaceSchema, count)
-      program.unsafeRunSync() shouldEqual (("cluster", "schema", Some("keyspace"), None, List("keyspace"), "schema", 6))
+      } yield (
+        clusterName,
+        schema,
+        keyspace.map(_.name),
+        missing,
+        keyspaces.map(_.name),
+        keyspaceSchema,
+        count,
+      )
+      program.unsafeRunSync() shouldEqual
+        (("cluster", "schema", Some("keyspace"), None, List("keyspace"), "schema", 6))
     }
   }
 
@@ -69,7 +79,8 @@ class MetadataSpec extends AnyWordSpec with Matchers {
         userTypes <- keyspace1.userTypes
         count <- counter.get
       } yield (schema, cql, table.map(_.name), missing, tables.map(_.name), replication, userTypes, count)
-      program.unsafeRunSync() shouldEqual (("schema", "cql", Some("table"), None, List("table"), Map("class" -> "SimpleStrategy"), Nil, 7))
+      program.unsafeRunSync() shouldEqual
+        (("schema", "cql", Some("table"), None, List("table"), Map("class" -> "SimpleStrategy"), Nil, 7))
       val keyspace1 = keyspaceMetadata.mapK(cats.arrow.FunctionK.id[IO])
       keyspace1.name shouldEqual "keyspace"
       keyspace1.durableWrites shouldEqual true

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
@@ -2,6 +2,7 @@ package com.evolutiongaming.scassandra
 
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Ref}
+import cats.syntax.all.*
 import cats.~>
 import com.datastax.driver.core.UserType
 import org.scalatest.matchers.should.Matchers
@@ -48,7 +49,7 @@ class MetadataSpec extends AnyWordSpec with Matchers {
         keyspace <- metadata1.keyspace("keyspace")
         missing <- metadata1.keyspace("missing")
         keyspaces <- metadata1.keyspaces
-        keyspaceSchema <- keyspace.get.schema
+        keyspaceSchema <- keyspace.traverse(_.schema)
         count <- counter.get
       } yield (
         clusterName,
@@ -60,7 +61,7 @@ class MetadataSpec extends AnyWordSpec with Matchers {
         count,
       )
       program.unsafeRunSync() shouldEqual
-        (("cluster", "schema", Some("keyspace"), None, List("keyspace"), "schema", 6))
+        (("cluster", "schema", Some("keyspace"), None, List("keyspace"), Some("schema"), 6))
     }
   }
 

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MetadataSpec.scala
@@ -1,0 +1,79 @@
+package com.evolutiongaming.scassandra
+
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
+import cats.~>
+import com.datastax.driver.core.UserType
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class MetadataSpec extends AnyWordSpec with Matchers {
+
+  private val tableMetadata: TableMetadata = new TableMetadata {
+    def name: String = "table"
+  }
+
+  private val keyspaceMetadata: KeyspaceMetadata[IO] = new KeyspaceMetadata[IO] {
+    def name: String = "keyspace"
+    def schema: IO[String] = IO.pure("schema")
+    def asCql: IO[String] = IO.pure("cql")
+    def table(name: String): IO[Option[TableMetadata]] = IO.pure(Option.when(name == "table")(tableMetadata))
+    def tables: IO[List[TableMetadata]] = IO.pure(List(tableMetadata))
+    def durableWrites: Boolean = true
+    def virtual: Boolean = false
+    def replication: IO[Map[String, String]] = IO.pure(Map("class" -> "SimpleStrategy"))
+    def userTypes: IO[List[UserType]] = IO.pure(Nil)
+  }
+
+  private val metadata: Metadata[IO] = new Metadata[IO] {
+    def clusterName: IO[String] = IO.pure("cluster")
+    def keyspace(name: String): IO[Option[KeyspaceMetadata[IO]]] = IO.pure(Option.when(name == "keyspace")(keyspaceMetadata))
+    def keyspaces: IO[List[KeyspaceMetadata[IO]]] = IO.pure(List(keyspaceMetadata))
+    def schema: IO[String] = IO.pure("schema")
+  }
+
+  private def counting(counter: Ref[IO, Int]): IO ~> IO = new (IO ~> IO) {
+    def apply[A](fa: IO[A]): IO[A] = counter.update(_ + 1) *> fa
+  }
+
+  "Metadata.mapK" should {
+
+    "delegate every call through the transformation" in {
+      val program = for {
+        counter <- Ref[IO].of(0)
+        metadata1 = metadata.mapK(counting(counter))
+        clusterName <- metadata1.clusterName
+        schema <- metadata1.schema
+        keyspace <- metadata1.keyspace("keyspace")
+        missing <- metadata1.keyspace("missing")
+        keyspaces <- metadata1.keyspaces
+        keyspaceSchema <- keyspace.get.schema
+        count <- counter.get
+      } yield (clusterName, schema, keyspace.map(_.name), missing, keyspaces.map(_.name), keyspaceSchema, count)
+      program.unsafeRunSync() shouldEqual (("cluster", "schema", Some("keyspace"), None, List("keyspace"), "schema", 6))
+    }
+  }
+
+  "KeyspaceMetadata.mapK" should {
+
+    "delegate every call through the transformation" in {
+      val program = for {
+        counter <- Ref[IO].of(0)
+        keyspace1 = keyspaceMetadata.mapK(counting(counter))
+        schema <- keyspace1.schema
+        cql <- keyspace1.asCql
+        table <- keyspace1.table("table")
+        missing <- keyspace1.table("missing")
+        tables <- keyspace1.tables
+        replication <- keyspace1.replication
+        userTypes <- keyspace1.userTypes
+        count <- counter.get
+      } yield (schema, cql, table.map(_.name), missing, tables.map(_.name), replication, userTypes, count)
+      program.unsafeRunSync() shouldEqual (("schema", "cql", Some("table"), None, List("table"), Map("class" -> "SimpleStrategy"), Nil, 7))
+      val keyspace1 = keyspaceMetadata.mapK(cats.arrow.FunctionK.id[IO])
+      keyspace1.name shouldEqual "keyspace"
+      keyspace1.durableWrites shouldEqual true
+      keyspace1.virtual shouldEqual false
+    }
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/MockSupport.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/MockSupport.scala
@@ -1,0 +1,6 @@
+package com.evolutiongaming.scassandra
+
+object MockSupport {
+
+  def notSupported[A]: A = sys.error("not supported")
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/PoolingConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/PoolingConfigSpec.scala
@@ -1,11 +1,13 @@
 package com.evolutiongaming.scassandra
 
 import cats.implicits.*
+import com.datastax.driver.core.HostDistance
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
 class PoolingConfigSpec extends AnyFunSuite with Matchers {
@@ -36,5 +38,59 @@ class PoolingConfigSpec extends AnyFunSuite with Matchers {
       heartbeatInterval = 4.hours,
     )
     ConfigSource.fromConfig(config).load[PoolingConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava") {
+    val options = PoolingConfig(
+      local = PoolingConfig.HostConfig(
+        newConnectionThreshold = 100,
+        maxRequestsPerConnection = 1000,
+        connectionsPerHostMin = 2,
+        connectionsPerHostMax = 3,
+      ),
+      remote = PoolingConfig.HostConfig(
+        newConnectionThreshold = 50,
+        maxRequestsPerConnection = 500,
+        connectionsPerHostMin = 1,
+        connectionsPerHostMax = 2,
+      ),
+      poolTimeout = 1.second,
+      idleTimeout = 2.minutes,
+      maxQueueSize = 3,
+      heartbeatInterval = 4.seconds,
+    ).asJava
+    options.getNewConnectionThreshold(HostDistance.LOCAL) shouldEqual 100
+    options.getMaxRequestsPerConnection(HostDistance.LOCAL) shouldEqual 1000
+    options.getCoreConnectionsPerHost(HostDistance.LOCAL) shouldEqual 2
+    options.getMaxConnectionsPerHost(HostDistance.LOCAL) shouldEqual 3
+    options.getNewConnectionThreshold(HostDistance.REMOTE) shouldEqual 50
+    options.getMaxRequestsPerConnection(HostDistance.REMOTE) shouldEqual 500
+    options.getCoreConnectionsPerHost(HostDistance.REMOTE) shouldEqual 1
+    options.getMaxConnectionsPerHost(HostDistance.REMOTE) shouldEqual 2
+    options.getPoolTimeoutMillis shouldEqual 1000
+    options.getIdleTimeoutSeconds shouldEqual 120
+    options.getMaxQueueSize shouldEqual 3
+    options.getHeartbeatIntervalSeconds shouldEqual 4
+  }
+
+  test("fromConfig falls back per field") {
+    val config = ConfigFactory.parseString("""
+      local { connections-per-host-max = 9, new-connection-threshold = nope }
+      remote = nope
+      pool-timeout = nope
+      max-queue-size = 7
+    """)
+    val expected = PoolingConfig.Default.copy(
+      local = PoolingConfig.HostConfig.Local.copy(connectionsPerHostMax = 9),
+      maxQueueSize = 7,
+    )
+    PoolingConfig.fromConfig(config, PoolingConfig.Default) shouldEqual expected
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("max-queue-size = 7")
+    (PoolingConfig(config): @nowarn("cat=deprecation")) shouldEqual PoolingConfig(maxQueueSize = 7)
+    (PoolingConfig(config, PoolingConfig.Default): @nowarn("cat=deprecation")) shouldEqual
+      PoolingConfig(maxQueueSize = 7)
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ProxyMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ProxyMock.scala
@@ -1,0 +1,31 @@
+package com.evolutiongaming.scassandra
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import scala.reflect.ClassTag
+
+object ProxyMock {
+
+  def apply[A](
+    handler: PartialFunction[(String, List[AnyRef]), AnyRef],
+  )(implicit
+    tag: ClassTag[A],
+  ): A = {
+    val clazz = tag.runtimeClass
+    val invocationHandler = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
+        val arguments = Option(args).fold(List.empty[AnyRef])(_.toList)
+        val call = (method.getName, arguments)
+        if (handler.isDefinedAt(call)) handler(call)
+        else {
+          method.getName match {
+            case "toString" => s"${ clazz.getSimpleName }Mock"
+            case "hashCode" => Int.box(System.identityHashCode(proxy))
+            case "equals" => Boolean.box(arguments.head eq proxy)
+            case name => sys.error(s"${ clazz.getSimpleName }.$name is not supported")
+          }
+        }
+      }
+    }
+    Proxy.newProxyInstance(clazz.getClassLoader, Array[Class[?]](clazz), invocationHandler).asInstanceOf[A]
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ProxyMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ProxyMock.scala
@@ -14,16 +14,16 @@ object ProxyMock {
     val invocationHandler = new InvocationHandler {
       override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
         val arguments = Option(args).fold(List.empty[AnyRef])(_.toList)
-        val call = (method.getName, arguments)
-        if (handler.isDefinedAt(call)) handler(call)
-        else {
-          method.getName match {
-            case "toString" => s"${ clazz.getSimpleName }Mock"
-            case "hashCode" => Int.box(System.identityHashCode(proxy))
-            case "equals" => Boolean.box(arguments.head eq proxy)
-            case name => sys.error(s"${ clazz.getSimpleName }.$name is not supported")
-          }
-        }
+        handler.applyOrElse(
+          (method.getName, arguments),
+          (_: (String, List[AnyRef])) =>
+            method.getName match {
+              case "toString" => s"${ clazz.getSimpleName }Mock"
+              case "hashCode" => Int.box(System.identityHashCode(proxy))
+              case "equals" => Boolean.box(arguments.head eq proxy)
+              case name => sys.error(s"${ clazz.getSimpleName }.$name is not supported")
+            },
+        )
       }
     }
     Proxy.newProxyInstance(clazz.getClassLoader, Array[Class[?]](clazz), invocationHandler).asInstanceOf[A]

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/QueryConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/QueryConfigSpec.scala
@@ -7,6 +7,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
 class QueryConfigSpec extends AnyFunSuite with Matchers {
@@ -34,5 +35,48 @@ class QueryConfigSpec extends AnyFunSuite with Matchers {
     )
     val config = ConfigFactory.parseURL(getClass.getResource("query.conf"))
     ConfigSource.fromConfig(config).load[QueryConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava") {
+    val options = QueryConfig(
+      consistency = ConsistencyLevel.ALL,
+      serialConsistency = ConsistencyLevel.LOCAL_SERIAL,
+      fetchSize = 1,
+      defaultIdempotence = true,
+      maxPendingRefreshNodeListRequests = 2,
+      maxPendingRefreshNodeRequests = 3,
+      maxPendingRefreshSchemaRequests = 4,
+      refreshNodeListInterval = 5.seconds,
+      refreshNodeInterval = 6.seconds,
+      refreshSchemaInterval = 7.seconds,
+      metadata = false,
+      rePrepareOnUp = false,
+      prepareOnAllHosts = false,
+    ).asJava
+    options.getConsistencyLevel shouldEqual ConsistencyLevel.ALL
+    options.getSerialConsistencyLevel shouldEqual ConsistencyLevel.LOCAL_SERIAL
+    options.getFetchSize shouldEqual 1
+    options.getDefaultIdempotence shouldEqual true
+    options.getMaxPendingRefreshNodeListRequests shouldEqual 2
+    options.getMaxPendingRefreshNodeRequests shouldEqual 3
+    options.getMaxPendingRefreshSchemaRequests shouldEqual 4
+    options.getRefreshNodeListIntervalMillis shouldEqual 5000
+    options.getRefreshNodeIntervalMillis shouldEqual 6000
+    options.getRefreshSchemaIntervalMillis shouldEqual 7000
+    options.isMetadataEnabled shouldEqual false
+    options.isReprepareOnUp shouldEqual false
+    options.isPrepareOnAllHosts shouldEqual false
+  }
+
+  test("fromConfig falls back to default on invalid config") {
+    val config = ConfigFactory.parseString("fetch-size = nope")
+    QueryConfig.fromConfig(config, QueryConfig.Default) shouldEqual QueryConfig.Default
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("fetch-size = 7")
+    (QueryConfig(config): @nowarn("cat=deprecation")) shouldEqual QueryConfig(fetchSize = 7)
+    (QueryConfig(config, QueryConfig.Default): @nowarn("cat=deprecation")) shouldEqual
+      QueryConfig(fetchSize = 7)
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ReconnectionConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ReconnectionConfigSpec.scala
@@ -1,11 +1,13 @@
 package com.evolutiongaming.scassandra
 
 import cats.implicits.*
+import com.datastax.driver.core.policies.ExponentialReconnectionPolicy
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
 class ReconnectionConfigSpec extends AnyFunSuite with Matchers {
@@ -22,5 +24,25 @@ class ReconnectionConfigSpec extends AnyFunSuite with Matchers {
       maxDelay = 2.seconds,
     )
     ConfigSource.fromConfig(config).load[ReconnectionConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava") {
+    val policy = ReconnectionConfig(minDelay = 1.second, maxDelay = 2.minutes).asJava
+    policy shouldBe a[ExponentialReconnectionPolicy]
+    policy.asInstanceOf[ExponentialReconnectionPolicy].getBaseDelayMs shouldEqual 1000
+    policy.asInstanceOf[ExponentialReconnectionPolicy].getMaxDelayMs shouldEqual 120000
+  }
+
+  test("fromConfig falls back to default on invalid config") {
+    val config = ConfigFactory.parseString("min-delay = nope")
+    ReconnectionConfig.fromConfig(config, ReconnectionConfig.Default) shouldEqual ReconnectionConfig.Default
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("max-delay = 3s")
+    (ReconnectionConfig(config): @nowarn("cat=deprecation")) shouldEqual
+      ReconnectionConfig(maxDelay = 3.seconds)
+    (ReconnectionConfig(config, ReconnectionConfig.Default): @nowarn("cat=deprecation")) shouldEqual
+      ReconnectionConfig(maxDelay = 3.seconds)
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
@@ -2,9 +2,10 @@ package com.evolutiongaming.scassandra
 
 import com.datastax.driver.core.{ColumnDefinitions, ExecutionInfo, ResultSet, ResultSetFuture, Row}
 import com.evolutiongaming.scassandra.MockSupport.notSupported
+import com.google.common.util.concurrent.ForwardingListenableFuture.SimpleForwardingListenableFuture
 import com.google.common.util.concurrent.{Futures, ListenableFuture}
 
-import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.concurrent.TimeUnit
 import java.util.{Iterator as IteratorJ, List as ListJ}
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.*
@@ -79,22 +80,11 @@ object RowMock {
 object ResultSetFutureMock {
 
   def apply(resultSet: ResultSet): ResultSetFuture = {
-    val underlying = Futures.immediateFuture(resultSet)
-    val handler = new InvocationHandler {
-      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
-        if (method.getDeclaringClass.isInstance(underlying)) {
-          method.invoke(underlying, Option(args).getOrElse(Array.empty[AnyRef])*)
-        } else {
-          sys.error(s"ResultSetFuture.${ method.getName } is not supported")
-        }
-      }
+    new SimpleForwardingListenableFuture[ResultSet](Futures.immediateFuture(resultSet)) with ResultSetFuture {
+
+      override def getUninterruptibly(): ResultSet = resultSet
+
+      override def getUninterruptibly(timeout: Long, unit: TimeUnit): ResultSet = resultSet
     }
-    Proxy
-      .newProxyInstance(
-        classOf[ResultSetFuture].getClassLoader,
-        Array[Class[?]](classOf[ResultSetFuture]),
-        handler,
-      )
-      .asInstanceOf[ResultSetFuture]
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
@@ -1,6 +1,7 @@
 package com.evolutiongaming.scassandra
 
 import com.datastax.driver.core.{ColumnDefinitions, ExecutionInfo, ResultSet, ResultSetFuture, Row}
+import com.evolutiongaming.scassandra.MockSupport.notSupported
 import com.google.common.util.concurrent.{Futures, ListenableFuture}
 
 import java.lang.reflect.{InvocationHandler, Method, Proxy}
@@ -48,13 +49,13 @@ final class ResultSetMock(pages: List[List[Row]]) extends ResultSet {
     }
   }
 
-  override def getExecutionInfo: ExecutionInfo = sys.error("not supported")
+  override def getExecutionInfo: ExecutionInfo = notSupported
 
-  override def getAllExecutionInfo: ListJ[ExecutionInfo] = sys.error("not supported")
+  override def getAllExecutionInfo: ListJ[ExecutionInfo] = notSupported
 
-  override def getColumnDefinitions: ColumnDefinitions = sys.error("not supported")
+  override def getColumnDefinitions: ColumnDefinitions = notSupported
 
-  override def wasApplied(): Boolean = sys.error("not supported")
+  override def wasApplied(): Boolean = notSupported
 }
 
 object ResultSetMock {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
@@ -89,7 +89,11 @@ object ResultSetFutureMock {
       }
     }
     Proxy
-      .newProxyInstance(classOf[ResultSetFuture].getClassLoader, Array[Class[?]](classOf[ResultSetFuture]), handler)
+      .newProxyInstance(
+        classOf[ResultSetFuture].getClassLoader,
+        Array[Class[?]](classOf[ResultSetFuture]),
+        handler,
+      )
       .asInstanceOf[ResultSetFuture]
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetMock.scala
@@ -1,0 +1,95 @@
+package com.evolutiongaming.scassandra
+
+import com.datastax.driver.core.{ColumnDefinitions, ExecutionInfo, ResultSet, ResultSetFuture, Row}
+import com.google.common.util.concurrent.{Futures, ListenableFuture}
+
+import java.lang.reflect.{InvocationHandler, Method, Proxy}
+import java.util.{Iterator as IteratorJ, List as ListJ}
+import scala.collection.mutable
+import scala.jdk.CollectionConverters.*
+
+final class ResultSetMock(pages: List[List[Row]]) extends ResultSet {
+
+  private var remaining: List[List[Row]] = pages.drop(1)
+  private val buffer: mutable.Queue[Row] = mutable.Queue.from(pages.headOption.getOrElse(Nil))
+  private var fetches: Int = 0
+
+  def fetchCount: Int = synchronized { fetches }
+
+  override def isExhausted: Boolean = synchronized { buffer.isEmpty && remaining.isEmpty }
+
+  override def isFullyFetched: Boolean = synchronized { remaining.isEmpty }
+
+  override def getAvailableWithoutFetching: Int = synchronized { buffer.size }
+
+  override def fetchMoreResults(): ListenableFuture[ResultSet] = synchronized {
+    remaining match {
+      case page :: rest =>
+        fetches += 1
+        remaining = rest
+        buffer.enqueueAll(page)
+      case Nil =>
+    }
+    Futures.immediateFuture(this)
+  }
+
+  override def one(): Row = synchronized { if (buffer.isEmpty) null else buffer.dequeue() }
+
+  override def all(): ListJ[Row] = synchronized {
+    while (!isFullyFetched) fetchMoreResults()
+    buffer.dequeueAll(_ => true).asJava
+  }
+
+  override def iterator(): IteratorJ[Row] = new IteratorJ[Row] {
+    override def hasNext: Boolean = !isExhausted
+    override def next(): Row = ResultSetMock.this.synchronized {
+      if (buffer.isEmpty) fetchMoreResults()
+      buffer.dequeue()
+    }
+  }
+
+  override def getExecutionInfo: ExecutionInfo = sys.error("not supported")
+
+  override def getAllExecutionInfo: ListJ[ExecutionInfo] = sys.error("not supported")
+
+  override def getColumnDefinitions: ColumnDefinitions = sys.error("not supported")
+
+  override def wasApplied(): Boolean = sys.error("not supported")
+}
+
+object ResultSetMock {
+
+  def apply(pages: List[Row]*): ResultSetMock = new ResultSetMock(pages.toList)
+
+  def rows(ids: Int*): List[Row] = ids.toList.map(RowMock(_))
+}
+
+object RowMock {
+
+  def apply(id: Int): Row = ProxyMock[Row] {
+    case ("getInt", _) => Int.box(id)
+    case ("toString", Nil) => s"RowMock($id)"
+    case ("hashCode", Nil) => Int.box(id)
+  }
+
+  def id(row: Row): Int = row.getInt(0)
+}
+
+object ResultSetFutureMock {
+
+  def apply(resultSet: ResultSet): ResultSetFuture = {
+    val underlying = Futures.immediateFuture(resultSet)
+    val handler = new InvocationHandler {
+      override def invoke(proxy: AnyRef, method: Method, args: Array[AnyRef]): AnyRef = {
+        if (method.getDeclaringClass.isInstance(underlying)) {
+          method.invoke(underlying, Option(args).getOrElse(Array.empty[AnyRef])*)
+        } else {
+          sys.error(s"ResultSetFuture.${ method.getName } is not supported")
+        }
+      }
+    }
+    Proxy
+      .newProxyInstance(classOf[ResultSetFuture].getClassLoader, Array[Class[?]](classOf[ResultSetFuture]), handler)
+      .asInstanceOf[ResultSetFuture]
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
@@ -10,7 +10,6 @@ import com.evolutiongaming.sstream.Stream.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
   private def session(resultSet: ResultSet, executed: Statement => Unit = _ => ()): CassandraSession[IO] = {
@@ -26,7 +25,10 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
   private val streams: List[(String, ResultSetMock => Stream[IO, Row])] = List(
     ("ResultSet.stream", resultSet => resultSet.stream[IO]),
-    ("executeStream(statement)", resultSet => session(resultSet).executeStream(new SimpleStatement("SELECT 1"))),
+    (
+      "executeStream(statement)",
+      resultSet => session(resultSet).executeStream(new SimpleStatement("SELECT 1")),
+    ),
     ("executeStream(query)", resultSet => session(resultSet).executeStream("SELECT 1")),
   )
 
@@ -48,7 +50,8 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
       }
 
       "return all rows across pages in order, fetching every next page once" in {
-        val resultSet = ResultSetMock(ResultSetMock.rows(1, 2), ResultSetMock.rows(3), ResultSetMock.rows(4, 5))
+        val resultSet =
+          ResultSetMock(ResultSetMock.rows(1, 2), ResultSetMock.rows(3), ResultSetMock.rows(4, 5))
         ids(stream(resultSet).toList.unsafeRunSync()) shouldEqual List(1, 2, 3, 4, 5)
         resultSet.fetchCount shouldEqual 2
       }
@@ -79,7 +82,10 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
     "wrap the query into a SimpleStatement" in {
       var executed = Option.empty[Statement]
-      session(ResultSetMock(), statement => executed = Some(statement)).executeStream("SELECT 1").toList.unsafeRunSync()
+      session(
+        ResultSetMock(),
+        statement => executed = Some(statement),
+      ).executeStream("SELECT 1").toList.unsafeRunSync()
       executed.map(_.asInstanceOf[SimpleStatement].getQueryString) shouldEqual Some("SELECT 1")
     }
   }
@@ -89,7 +95,10 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
     "execute the statement as is" in {
       var executed = Option.empty[Statement]
       val statement = new SimpleStatement("SELECT 1")
-      session(ResultSetMock(), statement => executed = Some(statement)).executeStream(statement).toList.unsafeRunSync()
+      session(
+        ResultSetMock(),
+        statement => executed = Some(statement),
+      ).executeStream(statement).toList.unsafeRunSync()
       executed.map(_ eq statement) shouldEqual Some(true)
     }
   }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
@@ -12,6 +12,8 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
+  private val query = "SELECT 1"
+
   private def session(resultSet: ResultSet, executed: Statement => Unit = _ => ()): CassandraSession[IO] = {
     new CassandraSessionMock {
       override def execute(statement: Statement): IO[ResultSet] = IO {
@@ -27,9 +29,9 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
     ("ResultSet.stream", resultSet => resultSet.stream[IO]),
     (
       "executeStream(statement)",
-      resultSet => session(resultSet).executeStream(new SimpleStatement("SELECT 1")),
+      resultSet => session(resultSet).executeStream(new SimpleStatement(query)),
     ),
-    ("executeStream(query)", resultSet => session(resultSet).executeStream("SELECT 1")),
+    ("executeStream(query)", resultSet => session(resultSet).executeStream(query)),
   )
 
   for {
@@ -85,8 +87,8 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
       session(
         ResultSetMock(),
         statement => executed = Some(statement),
-      ).executeStream("SELECT 1").toList.unsafeRunSync()
-      executed.map(_.asInstanceOf[SimpleStatement].getQueryString) shouldEqual Some("SELECT 1")
+      ).executeStream(query).toList.unsafeRunSync()
+      executed.map(_.asInstanceOf[SimpleStatement].getQueryString) shouldEqual Some(query)
     }
   }
 
@@ -94,7 +96,7 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
     "execute the statement as is" in {
       var executed = Option.empty[Statement]
-      val statement = new SimpleStatement("SELECT 1")
+      val statement = new SimpleStatement(query)
       session(
         ResultSetMock(),
         statement => executed = Some(statement),

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
@@ -1,7 +1,7 @@
 package com.evolutiongaming.scassandra
 
-import cats.effect.IO
 import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Ref}
 import com.datastax.driver.core.{ResultSet, Row, SimpleStatement, Statement}
 import com.evolutiongaming.scassandra.StreamingCassandraSession.*
 import com.evolutiongaming.scassandra.syntax.*
@@ -14,12 +14,13 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
 
   private val query = "SELECT 1"
 
-  private def session(resultSet: ResultSet, executed: Statement => Unit = _ => ()): CassandraSession[IO] = {
+  private def session(
+    resultSet: ResultSet,
+    executed: Ref[IO, List[Statement]] = Ref.unsafe[IO, List[Statement]](Nil),
+  ): CassandraSession[IO] = {
     new CassandraSessionMock {
-      override def execute(statement: Statement): IO[ResultSet] = IO {
-        executed(statement)
-        resultSet
-      }
+      override def execute(statement: Statement): IO[ResultSet] =
+        executed.update(_ :+ statement).as(resultSet)
     }
   }
 
@@ -83,26 +84,25 @@ class ResultSetStreamSpec extends AnyWordSpec with Matchers {
   "executeStream(query)" should {
 
     "wrap the query into a SimpleStatement" in {
-      var executed = Option.empty[Statement]
-      session(
-        ResultSetMock(),
-        statement => executed = Some(statement),
-      ).executeStream(query).toList.unsafeRunSync()
-      executed.map(_.asInstanceOf[SimpleStatement].getQueryString) shouldEqual Some(query)
+      val program = for {
+        executed <- Ref[IO].of(List.empty[Statement])
+        _ <- session(ResultSetMock(), executed).executeStream(query).toList
+        executed <- executed.get
+      } yield executed.map(_.asInstanceOf[SimpleStatement].getQueryString)
+      program.unsafeRunSync() shouldEqual List(query)
     }
   }
 
   "executeStream(statement)" should {
 
     "execute the statement as is" in {
-      var executed = Option.empty[Statement]
       val statement = new SimpleStatement(query)
-      session(
-        ResultSetMock(),
-        statement => executed = Some(statement),
-      ).executeStream(statement).toList.unsafeRunSync()
-      executed.map(_ eq statement) shouldEqual Some(true)
+      val program = for {
+        executed <- Ref[IO].of(List.empty[Statement])
+        _ <- session(ResultSetMock(), executed).executeStream(statement).toList
+        executed <- executed.get
+      } yield executed.map(_ eq statement)
+      program.unsafeRunSync() shouldEqual List(true)
     }
   }
-
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ResultSetStreamSpec.scala
@@ -1,0 +1,97 @@
+package com.evolutiongaming.scassandra
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import com.datastax.driver.core.{ResultSet, Row, SimpleStatement, Statement}
+import com.evolutiongaming.scassandra.StreamingCassandraSession.*
+import com.evolutiongaming.scassandra.syntax.*
+import com.evolutiongaming.sstream.Stream
+import com.evolutiongaming.sstream.Stream.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+
+class ResultSetStreamSpec extends AnyWordSpec with Matchers {
+
+  private def session(resultSet: ResultSet, executed: Statement => Unit = _ => ()): CassandraSession[IO] = {
+    new CassandraSessionMock {
+      override def execute(statement: Statement): IO[ResultSet] = IO {
+        executed(statement)
+        resultSet
+      }
+    }
+  }
+
+  private def ids(rows: List[Row]): List[Int] = rows.map(RowMock.id)
+
+  private val streams: List[(String, ResultSetMock => Stream[IO, Row])] = List(
+    ("ResultSet.stream", resultSet => resultSet.stream[IO]),
+    ("executeStream(statement)", resultSet => session(resultSet).executeStream(new SimpleStatement("SELECT 1"))),
+    ("executeStream(query)", resultSet => session(resultSet).executeStream("SELECT 1")),
+  )
+
+  for {
+    (name, stream) <- streams
+  } {
+    name should {
+
+      "return no rows for an empty result set" in {
+        val resultSet = ResultSetMock()
+        stream(resultSet).toList.unsafeRunSync() shouldEqual Nil
+        resultSet.fetchCount shouldEqual 0
+      }
+
+      "return all rows of a single page without fetching" in {
+        val resultSet = ResultSetMock(ResultSetMock.rows(1, 2, 3))
+        ids(stream(resultSet).toList.unsafeRunSync()) shouldEqual List(1, 2, 3)
+        resultSet.fetchCount shouldEqual 0
+      }
+
+      "return all rows across pages in order, fetching every next page once" in {
+        val resultSet = ResultSetMock(ResultSetMock.rows(1, 2), ResultSetMock.rows(3), ResultSetMock.rows(4, 5))
+        ids(stream(resultSet).toList.unsafeRunSync()) shouldEqual List(1, 2, 3, 4, 5)
+        resultSet.fetchCount shouldEqual 2
+      }
+
+      "skip empty pages" in {
+        val resultSet = ResultSetMock(Nil, ResultSetMock.rows(1), Nil, ResultSetMock.rows(2))
+        ids(stream(resultSet).toList.unsafeRunSync()) shouldEqual List(1, 2)
+        resultSet.fetchCount shouldEqual 3
+      }
+
+      "stop when the fold completes" in {
+        val resultSet = ResultSetMock(ResultSetMock.rows(1, 2), ResultSetMock.rows(3))
+        val result = stream(resultSet).foldWhileM(List.empty[Int]) { (seen, row) =>
+          val seen1 = RowMock.id(row) :: seen
+          IO.pure(if (seen1.size == 2) Right(seen1.reverse) else Left(seen1))
+        }
+        result.unsafeRunSync() shouldEqual Right(List(1, 2))
+      }
+
+      "return the first row" in {
+        val resultSet = ResultSetMock(ResultSetMock.rows(1, 2), ResultSetMock.rows(3))
+        stream(resultSet).first.unsafeRunSync().map(RowMock.id) shouldEqual Some(1)
+      }
+    }
+  }
+
+  "executeStream(query)" should {
+
+    "wrap the query into a SimpleStatement" in {
+      var executed = Option.empty[Statement]
+      session(ResultSetMock(), statement => executed = Some(statement)).executeStream("SELECT 1").toList.unsafeRunSync()
+      executed.map(_.asInstanceOf[SimpleStatement].getQueryString) shouldEqual Some("SELECT 1")
+    }
+  }
+
+  "executeStream(statement)" should {
+
+    "execute the statement as is" in {
+      var executed = Option.empty[Statement]
+      val statement = new SimpleStatement("SELECT 1")
+      session(ResultSetMock(), statement => executed = Some(statement)).executeStream(statement).toList.unsafeRunSync()
+      executed.map(_ eq statement) shouldEqual Some(true)
+    }
+  }
+
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
@@ -17,7 +17,8 @@ class RowCodecSpec extends AnyWordSpec with Matchers {
     }
 
     "contramap" in {
-      EncodeRow[String]("key").contramap[Int](_.toString).apply(DataMock(), 1).byName shouldEqual Map("key" -> "1")
+      EncodeRow[String]("key").contramap[Int](_.toString).apply(DataMock(), 1).byName shouldEqual
+        Map("key" -> "1")
     }
 
     "have a Contravariant instance" in {

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
@@ -2,13 +2,12 @@ package com.evolutiongaming.scassandra
 
 import cats.{Contravariant, Functor}
 import com.datastax.driver.core.{GettableByNameData, SettableData, SimpleStatement}
+import com.evolutiongaming.scassandra.RowCodecSpec.*
 import com.evolutiongaming.scassandra.syntax.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class RowCodecSpec extends AnyWordSpec with Matchers {
-
-  import RowCodecSpec.*
 
   "EncodeRow" should {
 

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/RowCodecSpec.scala
@@ -1,0 +1,132 @@
+package com.evolutiongaming.scassandra
+
+import cats.{Contravariant, Functor}
+import com.datastax.driver.core.{GettableByNameData, SettableData, SimpleStatement}
+import com.evolutiongaming.scassandra.syntax.*
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class RowCodecSpec extends AnyWordSpec with Matchers {
+
+  import RowCodecSpec.*
+
+  "EncodeRow" should {
+
+    "encode a value under a fixed name" in {
+      EncodeRow[String]("key").apply(DataMock(), "value").byName shouldEqual Map("key" -> "value")
+    }
+
+    "contramap" in {
+      EncodeRow[String]("key").contramap[Int](_.toString).apply(DataMock(), 1).byName shouldEqual Map("key" -> "1")
+    }
+
+    "have a Contravariant instance" in {
+      val encode = Contravariant[EncodeRow].contramap(EncodeRow[String]("key"))((_: Int).toString)
+      encode(DataMock(), 2).byName shouldEqual Map("key" -> "2")
+    }
+
+    "be summoned and used via Ops" in {
+      EncodeRow[User].apply(DataMock(), User("name", 1)).byName shouldEqual user
+      new EncodeRow.Ops.SettableDataOps(DataMock()).encode(User("name", 1)).byName shouldEqual user
+    }
+  }
+
+  "DecodeRow" should {
+
+    "decode a value from a fixed name" in {
+      DecodeRow[String]("key").apply(DataMock(byName = Map("key" -> "value"))) shouldEqual "value"
+    }
+
+    "map" in {
+      DecodeRow[String]("key").map(_.length).apply(DataMock(byName = Map("key" -> "value"))) shouldEqual 5
+    }
+
+    "have a Functor instance" in {
+      val decode = Functor[DecodeRow].map(DecodeRow[String]("key"))(_.toUpperCase)
+      decode(DataMock(byName = Map("key" -> "value"))) shouldEqual "VALUE"
+    }
+
+    "be summoned and used via Ops" in {
+      val data = DataMock(byName = user)
+      DecodeRow[User].apply(data) shouldEqual User("name", 1)
+      new DecodeRow.Ops.GettableByNameDataOps(data).decode[User] shouldEqual User("name", 1)
+    }
+  }
+
+  "UpdateRow" should {
+
+    "be derived from EncodeRow" in {
+      UpdateRow[User].apply(DataMock(), User("name", 1)).byName shouldEqual user
+    }
+
+    "contramap" in {
+      val update = UpdateRow[User].contramap[String](User(_, 0))
+      update(DataMock(), "name").byName shouldEqual Map[String, Any]("name" -> "name", "age" -> 0)
+    }
+  }
+
+  "UpdateByName" should {
+
+    "contramap" in {
+      val update = UpdateByName[String].contramap[Int](_.toString)
+      update(DataMock(), "key", 1).byName shouldEqual Map("key" -> "1")
+    }
+  }
+
+  "UpdateByIdx" should {
+
+    "contramap" in {
+      val update = UpdateByIdx[String].contramap[Int](_.toString)
+      update(DataMock(), 0, 1).byIdx shouldEqual Map(0 -> "1")
+    }
+  }
+
+  "syntax" should {
+
+    "encode a row" in {
+      DataMock().encode(User("name", 1)).byName shouldEqual user
+    }
+
+    "encodeSome by name" in {
+      DataMock().encodeSome("key", Some("value")).byName shouldEqual Map("key" -> "value")
+      DataMock().encodeSome("key", None: Option[String]).byName shouldEqual Map.empty
+    }
+
+    "encodeSome a row" in {
+      DataMock().encodeSome(Some(User("name", 1))).byName shouldEqual user
+      DataMock().encodeSome(None: Option[User]).byName shouldEqual Map.empty
+    }
+
+    "decode a row" in {
+      DataMock(byName = user).decode[User] shouldEqual User("name", 1)
+    }
+
+    "update a row" in {
+      DataMock().update(User("name", 1)).byName shouldEqual user
+    }
+
+    "toggle statement tracing" in {
+      new SimpleStatement("SELECT 1").trace(enable = true).isTracing shouldEqual true
+      new SimpleStatement("SELECT 1").trace(enable = false).isTracing shouldEqual false
+    }
+  }
+}
+
+object RowCodecSpec {
+
+  final case class User(name: String, age: Int)
+
+  val user: Map[String, Any] = Map("name" -> "name", "age" -> 1)
+
+  implicit val encodeRowUser: EncodeRow[User] = new EncodeRow[User] {
+    def apply[B <: SettableData[B]](data: B, user: User): B = {
+      data
+        .encode("name", user.name)
+        .encode("age", user.age)
+    }
+  }
+
+  implicit val decodeRowUser: DecodeRow[User] = (data: GettableByNameData) => {
+    User(data.decode[String]("name"), data.decode[Int]("age"))
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/SocketConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/SocketConfigSpec.scala
@@ -6,6 +6,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
 class SocketConfigSpec extends AnyFunSuite with Matchers {
@@ -28,5 +29,50 @@ class SocketConfigSpec extends AnyFunSuite with Matchers {
       sendBufferSize = Some(5),
     )
     ConfigSource.fromConfig(config).load[SocketConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava") {
+    val options = SocketConfig(
+      connectTimeout = 1.second,
+      readTimeout = 2.seconds,
+      keepAlive = Some(true),
+      reuseAddress = Some(true),
+      soLinger = Some(3),
+      tcpNoDelay = Some(false),
+      receiveBufferSize = Some(4),
+      sendBufferSize = Some(5),
+    ).asJava
+    options.getConnectTimeoutMillis shouldEqual 1000
+    options.getReadTimeoutMillis shouldEqual 2000
+    options.getKeepAlive shouldEqual true
+    options.getReuseAddress shouldEqual true
+    options.getSoLinger shouldEqual 3
+    options.getTcpNoDelay shouldEqual false
+    options.getReceiveBufferSize shouldEqual 4
+    options.getSendBufferSize shouldEqual 5
+  }
+
+  test("asJava leaves unset options at driver defaults") {
+    val options = SocketConfig.Default.asJava
+    options.getConnectTimeoutMillis shouldEqual 5000
+    options.getReadTimeoutMillis shouldEqual 12000
+    options.getKeepAlive shouldBe null
+    options.getReuseAddress shouldBe null
+    options.getSoLinger shouldBe null
+    options.getTcpNoDelay shouldEqual true
+    options.getReceiveBufferSize shouldBe null
+    options.getSendBufferSize shouldBe null
+  }
+
+  test("fromConfig falls back to default on invalid config") {
+    val config = ConfigFactory.parseString("connect-timeout = nope")
+    SocketConfig.fromConfig(config, SocketConfig.Default) shouldEqual SocketConfig.Default
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("read-timeout = 3s")
+    (SocketConfig(config): @nowarn("cat=deprecation")) shouldEqual SocketConfig(readTimeout = 3.seconds)
+    (SocketConfig(config, SocketConfig.Default): @nowarn("cat=deprecation")) shouldEqual
+      SocketConfig(readTimeout = 3.seconds)
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/SpeculativeExecutionConfigSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/SpeculativeExecutionConfigSpec.scala
@@ -1,11 +1,13 @@
 package com.evolutiongaming.scassandra
 
 import cats.implicits.*
+import com.datastax.driver.core.policies.ConstantSpeculativeExecutionPolicy
 import com.typesafe.config.ConfigFactory
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import pureconfig.ConfigSource
 
+import scala.annotation.nowarn
 import scala.concurrent.duration.*
 
 class SpeculativeExecutionConfigSpec extends AnyFunSuite with Matchers {
@@ -23,5 +25,26 @@ class SpeculativeExecutionConfigSpec extends AnyFunSuite with Matchers {
       maxExecutions = 3,
     )
     ConfigSource.fromConfig(config).load[SpeculativeExecutionConfig] shouldEqual expected.asRight
+  }
+
+  test("asJava") {
+    SpeculativeExecutionConfig(delay = 1.second, maxExecutions = 3).asJava shouldBe
+      a[ConstantSpeculativeExecutionPolicy]
+  }
+
+  test("fromConfig falls back to default on invalid config") {
+    val config = ConfigFactory.parseString("delay = nope")
+    SpeculativeExecutionConfig.fromConfig(config, SpeculativeExecutionConfig.Default) shouldEqual
+      SpeculativeExecutionConfig.Default
+  }
+
+  test("deprecated apply") {
+    val config = ConfigFactory.parseString("max-executions = 5")
+    (SpeculativeExecutionConfig(config): @nowarn("cat=deprecation")) shouldEqual
+      SpeculativeExecutionConfig(maxExecutions = 5)
+    (SpeculativeExecutionConfig(
+      config,
+      SpeculativeExecutionConfig.Default,
+    ): @nowarn("cat=deprecation")) shouldEqual SpeculativeExecutionConfig(maxExecutions = 5)
   }
 }

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ToCqlSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ToCqlSpec.scala
@@ -1,0 +1,50 @@
+package com.evolutiongaming.scassandra
+
+import cats.Contravariant
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.annotation.nowarn
+
+class ToCqlSpec extends AnyWordSpec with Matchers {
+
+  private implicit val toCqlInt: ToCql[Int] = (a: Int) => a.toString
+
+  "ToCql" should {
+
+    "be summoned" in {
+      ToCql[String].apply("value") shouldEqual "value"
+      ToCql("value") shouldEqual "value"
+    }
+
+    "contramap" in {
+      ToCql[String].contramap[Boolean](_.toString).apply(true) shouldEqual "true"
+    }
+
+    "have a Contravariant instance" in {
+      Contravariant[ToCql].contramap(ToCql[String])((_: Boolean).toString).apply(false) shouldEqual "false"
+    }
+
+    "provide toCql via implicits" in {
+      import ToCql.implicits.*
+      "value".toCql shouldEqual "value"
+      1.toCql shouldEqual "1"
+    }
+
+    "provide toCql via syntax" in {
+      import com.evolutiongaming.scassandra.syntax.*
+      "value".toCql shouldEqual "value"
+      2.toCql shouldEqual "2"
+    }
+
+    "provide toCql via deprecated Ops" in {
+      viaDeprecatedOps("value") shouldEqual "value"
+    }
+  }
+
+  @nowarn("cat=deprecation")
+  private def viaDeprecatedOps(a: String): String = {
+    import ToCql.Ops.*
+    a.toCql
+  }
+}

--- a/scassandra/src/test/scala/com/evolutiongaming/scassandra/ToCqlSpec.scala
+++ b/scassandra/src/test/scala/com/evolutiongaming/scassandra/ToCqlSpec.scala
@@ -26,15 +26,13 @@ class ToCqlSpec extends AnyWordSpec with Matchers {
     }
 
     "provide toCql via implicits" in {
-      import ToCql.implicits.*
-      "value".toCql shouldEqual "value"
-      1.toCql shouldEqual "1"
+      new ToCql.implicits.IdOpsToCql("value").toCql shouldEqual "value"
+      new ToCql.implicits.IdOpsToCql(1).toCql shouldEqual "1"
     }
 
     "provide toCql via syntax" in {
-      import com.evolutiongaming.scassandra.syntax.*
-      "value".toCql shouldEqual "value"
-      2.toCql shouldEqual "2"
+      syntax.toCqlOps("value").toCql shouldEqual "value"
+      syntax.toCqlOps(2).toCql shouldEqual "2"
     }
 
     "provide toCql via deprecated Ops" in {
@@ -43,8 +41,5 @@ class ToCqlSpec extends AnyWordSpec with Matchers {
   }
 
   @nowarn("cat=deprecation")
-  private def viaDeprecatedOps(a: String): String = {
-    import ToCql.Ops.*
-    a.toCql
-  }
+  private def viaDeprecatedOps(a: String): String = new ToCql.Ops.IdOps(a).toCql
 }


### PR DESCRIPTION
Unit tests for the driver-facing code before the driver 4 migration: paging stream, cluster builder mapping, config asJava, session wiring, FromGFuture, health check statement, row codecs. 89 to 211 tests, statement coverage 51% to 88%. Also found allow-remote-dcs-for-local-consistency-level is parsed but never applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added broad automated coverage for Cassandra cluster and session behavior, health checks, result streaming, metadata mapping, row codecs, CQL generation, and configuration parsing.
  - Added validation for Java driver configuration conversion, defaults, malformed values, deprecated APIs, cancellation, retries, and policy behavior.
  - Added reusable test doubles for sessions, result sets, rows, futures, and driver components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->